### PR TITLE
Improve Turnstile error handling and document env var

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,11 @@ npm run dev
 
 Visit [http://localhost:3000](http://localhost:3000) to view the app.
 
+### Environment Variables
+
+Set `CLOUDFLARE_TURNSTILE_SECRET_KEY` with your Cloudflare Turnstile secret so the
+`verify-turnstile` Supabase function can validate tokens.
+
 ---
 
 ## 📚 Main Sections

--- a/supabase/functions/verify-turnstile/index.ts
+++ b/supabase/functions/verify-turnstile/index.ts
@@ -40,7 +40,7 @@ serve(async (req) => {
     if (!TURNSTILE_SECRET) {
       console.error('CLOUDFLARE_TURNSTILE_SECRET_KEY not found in environment');
       return new Response(
-        JSON.stringify({ success: false, error: 'Server configuration error' }),
+        JSON.stringify({ success: false, error: 'Server config missing' }),
         {
           status: 500,
           headers: { ...corsHeaders, 'Content-Type': 'application/json' },


### PR DESCRIPTION
## Summary
- return a clearer server error when CLOUDFLARE_TURNSTILE_SECRET_KEY is missing
- document the required variable in project setup instructions

## Testing
- `npm run lint` *(fails: @typescript-eslint/no-explicit-any and other errors)*

------
https://chatgpt.com/codex/tasks/task_e_6881105b2f98832e82d4c904c92e91a9