### PR TITLE
Improve AI page usability

### DIFF
--- a/src/components/GPTAssistant.tsx
+++ b/src/components/GPTAssistant.tsx
@@ -45,14 +45,16 @@ export default function GPTAssistant() {
       const data = await res.json();
       setResult(data.result || "No response received.");
     } catch (err) {
-      setResult("Failed to generate response.");
+      setResult(
+        "Failed to generate response. Please check your connection and try again later."
+      );
     } finally {
       setLoading(false);
     }
   }
 
   return (
-    <Card className="max-w-2xl mx-auto my-8">
+    <Card className="w-full max-w-2xl mx-auto my-8 px-4">
       <CardHeader>
         <CardTitle>Zwanski AI Assistant</CardTitle>
       </CardHeader>

--- a/src/pages/ai.tsx
+++ b/src/pages/ai.tsx
@@ -1,5 +1,24 @@
 import GPTAssistant from "@/components/GPTAssistant";
+import { Button } from "@/components/ui/button";
+import { ArrowLeft } from "lucide-react";
+import { useNavigate } from "react-router-dom";
 
 export default function AIAssistantPage() {
-  return <GPTAssistant />;
+  const navigate = useNavigate();
+
+  return (
+    <div className="container mx-auto px-4">
+      <div className="mt-4 mb-2">
+        <Button
+          variant="ghost"
+          onClick={() => navigate("/")}
+          className="gap-1"
+        >
+          <ArrowLeft className="h-4 w-4" />
+          Home
+        </Button>
+      </div>
+      <GPTAssistant />
+    </div>
+  );
 }


### PR DESCRIPTION
## Summary
- show a Home button on the AI page
- handle AI fetch errors more clearly
- tweak AI assistant card layout for small screens

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68843cb17d0c832ea8b0f7bf736d05d7