### PR TITLE
Add live threat map page

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -68,6 +68,7 @@ const Blog = lazy(() => import("./pages/Blog"));
 const RSS = lazy(() => import("./pages/RSS"));
 const Search = lazy(() => import("./pages/Search"));
 const AIAssistantPage = lazy(() => import("./pages/ai"));
+const ThreatMap = lazy(() => import("./pages/ThreatMap"));
 
 // Admin pages - separate chunk
 const AdminDashboard = lazy(() => import("./pages/admin/AdminDashboard"));
@@ -184,6 +185,7 @@ function App() {
                           <Route path="/infrastructure" element={<Infrastructure />} />
                           <Route path="/imei-check" element={<IMEICheck />} />
                           <Route path="/tools" element={<Tools />} />
+                          <Route path="/threat-map" element={<ThreatMap />} />
                           <Route path="/ai" element={<AIAssistantPage />} />
                           <Route path="/search" element={<Search />} />
                           <Route path="/rss" element={<RSS />} />

--- a/src/components/Navbar.tsx
+++ b/src/components/Navbar.tsx
@@ -13,7 +13,8 @@ import {
   Settings2,
   FileText,
   MessageSquare,
-  Bot
+  Bot,
+  Activity
 } from "lucide-react";
 import ZwanskiLogo from "./ZwanskiLogo";
 import { ThemeToggle } from "./ThemeToggle";
@@ -127,6 +128,7 @@ const Navbar = () => {
     { label: "Jobs", path: "/jobs", icon: Briefcase },
     { label: "Blog", path: "/blog", icon: FileText },
     { label: "Chat", path: "/chat", icon: MessageSquare },
+    { label: "Threat Map", path: "/threat-map", icon: Activity },
     { label: "AI", path: "/ai", icon: Bot },
   ];
 

--- a/src/context/translations/ar.ts
+++ b/src/context/translations/ar.ts
@@ -21,6 +21,7 @@ export const arTranslations = {
   "nav.freeImeiCheck": "فحص IMEI مجاني",
   "nav.joinTelegram": "انضم إلى تلغرام",
   "nav.liveChat": "دردشة مباشرة",
+  "nav.threatMap": "خريطة التهديدات",
 
   // Hero Section
   "hero.title": "شريكك في بناء وإصلاح وتأمين المستقبل الرقمي",
@@ -263,6 +264,10 @@ export const arTranslations = {
   "imei.features.instantDesc": "احصل على النتائج فوراً",
   "imei.features.free": "مجاني",
   "imei.features.freeDesc": "خدمة مجانية تماماً",
+
+  // Threat Map
+  "threatMap.title": "خريطة التهديدات الحية",
+  "threatMap.description": "شاهد الهجمات السيبرانية حول العالم مباشرةً من Radware.",
 
   // Footer
   "footer.rights": "جميع الحقوق محفوظة.",

--- a/src/context/translations/ber.ts
+++ b/src/context/translations/ber.ts
@@ -21,6 +21,7 @@ export const berTranslations = {
   "nav.freeImeiCheck": "Asenqed IMEI Ilelelli",
   "nav.joinTelegram": "Ddu ɣer Telegram",
   "nav.liveChat": "Adiwenni Usrid",
+  "nav.threatMap": "Tawant n Wugur",
 
   // Hero Section
   "hero.title": "Ameddakel-nwen di Usali, Aseɣru d Uḥraz n Ukra Umḍin",
@@ -263,6 +264,10 @@ export const berTranslations = {
   "imei.features.instantDesc": "Awi igmaḍ deg tallit",
   "imei.features.free": "Ilelelli",
   "imei.features.freeDesc": "Ameẓlu ilelelli s tlelli",
+
+  // Threat Map
+  "threatMap.title": "Tawant n Wugur Srid",
+  "threatMap.description": "Mukkneḍ iḍelli n tuccfa-iddan deg umaḍal s Radware.",
 
   // Footer
   "footer.rights": "Akk izerfan ḥerzen.",

--- a/src/context/translations/en.ts
+++ b/src/context/translations/en.ts
@@ -21,6 +21,7 @@ export const enTranslations = {
   "nav.freeImeiCheck": "Free IMEI Check",
   "nav.joinTelegram": "Join Telegram",
   "nav.liveChat": "Live Chat",
+  "nav.threatMap": "Threat Map",
 
   // Hero Section
   "hero.title": "Your Partner in Building, Repairing & Securing Digital Futures",
@@ -263,6 +264,10 @@ export const enTranslations = {
   "imei.features.instantDesc": "Get results immediately",
   "imei.features.free": "Free",
   "imei.features.freeDesc": "Completely free service",
+
+  // Threat Map
+  "threatMap.title": "Live Threat Map",
+  "threatMap.description": "Observe real-time cyber attacks around the world powered by Radware.",
 
   // Footer
   "footer.rights": "All rights reserved.",

--- a/src/context/translations/fr.ts
+++ b/src/context/translations/fr.ts
@@ -21,6 +21,7 @@ export const frTranslations = {
   "nav.freeImeiCheck": "Vérification IMEI Gratuite",
   "nav.joinTelegram": "Rejoindre Telegram",
   "nav.liveChat": "Chat en Direct",
+  "nav.threatMap": "Carte des Menaces",
 
   // Hero Section
   "hero.title": "Votre Partenaire pour Construire, Réparer et Sécuriser l'Avenir Numérique",
@@ -263,6 +264,10 @@ export const frTranslations = {
   "imei.features.instantDesc": "Obtenez des résultats immédiatement",
   "imei.features.free": "Gratuit",
   "imei.features.freeDesc": "Service complètement gratuit",
+
+  // Threat Map
+  "threatMap.title": "Carte des Menaces en Direct",
+  "threatMap.description": "Observez les cyberattaques en temps réel dans le monde grâce à Radware.",
 
   // Footer
   "footer.rights": "Tous droits réservés.",

--- a/src/context/translations/ha.ts
+++ b/src/context/translations/ha.ts
@@ -21,6 +21,7 @@ export const haTranslations = {
   "nav.freeImeiCheck": "Binciken IMEI Kyauta",
   "nav.joinTelegram": "Shiga Telegram",
   "nav.liveChat": "Hira kai tsaye",
+  "nav.threatMap": "Taswirar Barazana",
 
   // Hero Section
   "hero.title": "Abokin hulɗar ku wajen Ginawa, Gyarawa da Kare Makomar Dijital",
@@ -263,6 +264,10 @@ export const haTranslations = {
   "imei.features.instantDesc": "Sami sakamako nan take",
   "imei.features.free": "Kyauta",
   "imei.features.freeDesc": "Hidima ta gaba ɗaya kyauta",
+
+  // Threat Map
+  "threatMap.title": "Taswirar Barazana Kai Tsaye",
+  "threatMap.description": "Kallon hare-haren yanar gizo kai tsaye a duniya daga Radware.",
 
   // Footer
   "footer.rights": "Duk haƙƙoƙi an kiyaye su.",

--- a/src/pages/ThreatMap.tsx
+++ b/src/pages/ThreatMap.tsx
@@ -1,0 +1,43 @@
+import Navbar from "@/components/Navbar";
+import Footer from "@/components/Footer";
+import { Helmet } from "react-helmet-async";
+import { useLanguage } from "@/context/LanguageContext";
+
+const ThreatMap = () => {
+  const { t } = useLanguage();
+  return (
+    <>
+      <Helmet>
+        <title>{t("threatMap.title") + " - ZWANSKI TECH"}</title>
+        <meta name="description" content={t("threatMap.description")}
+        />
+      </Helmet>
+      <div className="flex flex-col min-h-screen">
+        <Navbar />
+        <main className="flex-grow">
+          <section className="py-20 bg-gradient-to-b from-background to-muted/20">
+            <div className="container mx-auto px-4">
+              <h1 className="text-4xl md:text-5xl font-bold text-center mb-6">
+                {t("threatMap.title").split(" ")[0]} <span className="text-gradient">{t("threatMap.title").split(" ").slice(1).join(" ")}</span>
+              </h1>
+              <p className="text-muted-foreground text-center mb-8 max-w-2xl mx-auto">
+                {t("threatMap.description")}
+              </p>
+              <div className="relative w-full" style={{ paddingBottom: "56.25%" }}>
+                <iframe
+                  src="https://livethreatmap.radware.com/"
+                  className="absolute top-0 left-0 w-full h-full rounded-lg border-none"
+                  allowFullScreen
+                  title="Radware Live Threat Map"
+                />
+              </div>
+            </div>
+          </section>
+        </main>
+        <Footer />
+      </div>
+    </>
+  );
+};
+
+export default ThreatMap;


### PR DESCRIPTION
## Summary
- create ThreatMap page with Radware iframe and translations
- add Threat Map to navigation bar
- route `/threat-map` in router
- translate labels in all supported languages

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_68844d73c148832eb4f3f6d7d04705bb