### PR TITLE
Fix CSP for hCaptcha

### DIFF
--- a/index.html
+++ b/index.html
@@ -28,7 +28,7 @@
     
     <!-- Security Headers -->
     <meta http-equiv="Strict-Transport-Security" content="max-age=31536000; includeSubDomains; preload">
-    <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' 'unsafe-inline' 'unsafe-eval' https://www.googletagmanager.com https://static.axept.io https://cdn.gpteng.co https://widget.trustpilot.com https://challenges.cloudflare.com; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; font-src 'self' https://fonts.gstatic.com; img-src 'self' data: https: https://*.trustpilot.com; connect-src 'self' https: wss: https://*.trustpilot.com https://challenges.cloudflare.com; frame-src 'self' https: https://challenges.cloudflare.com;">
+    <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' 'unsafe-inline' 'unsafe-eval' https://www.googletagmanager.com https://static.axept.io https://cdn.gpteng.co https://widget.trustpilot.com https://js.hcaptcha.com; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; font-src 'self' https://fonts.gstatic.com; img-src 'self' data: https: https://*.trustpilot.com; connect-src 'self' https: wss: https://*.trustpilot.com https://hcaptcha.com; frame-src 'self' https: https://hcaptcha.com;">
     <meta http-equiv="X-Content-Type-Options" content="nosniff">
     <meta http-equiv="X-Frame-Options" content="DENY">
     <meta http-equiv="X-XSS-Protection" content="1; mode=block">


### PR DESCRIPTION
## Summary
- update Content-Security-Policy in `index.html` to use hCaptcha domains instead of Cloudflare

## Testing
- `npm run lint` *(fails: Unexpected any errors)*

------
https://chatgpt.com/codex/tasks/task_e_68851ccf82e8832e9705a86ee1910161