### PR TITLE
Update verify-hcaptcha references

### DIFF
--- a/supabase/functions/verify-hcaptcha/index.ts
+++ b/supabase/functions/verify-hcaptcha/index.ts
@@ -50,7 +50,7 @@ serve(async (req) => {
 
     console.log('Sending verification request to hCaptcha');
 
-    // Verify the token with Cloudflare with timeout
+    // Verify the token with hCaptcha with timeout
     const formData = new FormData();
     formData.append('secret', HCAPTCHA_SECRET);
     formData.append('response', token);
@@ -66,7 +66,7 @@ serve(async (req) => {
     ]);
 
     if (!verifyResponse.ok) {
-      console.error('Cloudflare verification request failed:', verifyResponse.status);
+      console.error('hCaptcha verification request failed:', verifyResponse.status);
       throw new Error(`Verification request failed: ${verifyResponse.status}`);
     }
 


### PR DESCRIPTION
## Summary
- update comment and error log to mention hCaptcha instead of Cloudflare

## Testing
- `npm run lint` *(fails: 81 problems)*
- `npm run test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_68851cd6e0d0832eb74e17e4b2662002