### PR TITLE
Add contribution guidelines referencing captcha migration

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,17 @@ Set these in your Supabase project secrets so the `get-hcaptcha-config` and `ver
 
 ---
 
+## 📝 Contribution Guidelines
+
+We welcome pull requests! To contribute:
+
+1. Fork this repository and create a new branch for your changes.
+2. If your update relates to the recent migration from **Turnstile** to **hCaptcha**, mention this in your commit messages.
+3. Run `npm run lint` and ensure the project builds successfully with `npm run build`.
+4. Open a pull request describing your improvements.
+
+---
+
 ## 🤝 Contributing & Support
 
 - **Contact:** [support@zwanski.org](mailto:support@zwanski.org)


### PR DESCRIPTION
## Summary
- add contribution guidelines to README

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68851cd7c9a0832e89b1a8a2f78e1998