### PR TITLE
Fix hCaptcha config access

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,15 @@ HCAPTCHA_SECRET_KEY=your-secret-key-here
 ```
 
 Set these in your Supabase project secrets so the `get-hcaptcha-config` and `verify-hcaptcha` edge functions can work properly.
+Additionally, update `supabase/config.toml` to allow unauthenticated access to these functions:
+
+```toml
+[functions.verify-hcaptcha]
+verify_jwt = false
+
+[functions.get-hcaptcha-config]
+verify_jwt = false
+```
 
 ---
 

--- a/supabase/config.toml
+++ b/supabase/config.toml
@@ -6,3 +6,6 @@ verify_jwt = false
 
 [functions.verify-hcaptcha]
 verify_jwt = false
+
+[functions.get-hcaptcha-config]
+verify_jwt = false


### PR DESCRIPTION
## Summary
- allow unauthenticated access for `get-hcaptcha-config`
- document required entries in `supabase/config.toml`

## Testing
- `npm run lint` *(fails: @typescript-eslint errors)*

------
https://chatgpt.com/codex/tasks/task_e_688525302098832eb8b8b1fa03a7cdc8