### PR TITLE
Update auth redirects to retain page

### DIFF
--- a/src/pages/Profile.tsx
+++ b/src/pages/Profile.tsx
@@ -5,12 +5,13 @@ import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
 import { Button } from "@/components/ui/button";
 import { Badge } from "@/components/ui/badge";
 import { User, Mail, Calendar, MapPin } from "lucide-react";
-import { Navigate } from "react-router-dom";
+import { Navigate, useLocation } from "react-router-dom";
 import { useQuery } from "@tanstack/react-query";
 import { supabase } from "@/integrations/supabase/client";
 
 export default function Profile() {
   const { user, isAuthenticated } = useAuth();
+  const location = useLocation();
 
   // Fetch user activity stats
   const { data: userStats } = useQuery({
@@ -36,7 +37,12 @@ export default function Profile() {
   });
 
   if (!isAuthenticated) {
-    return <Navigate to="/auth" replace />;
+    return (
+      <Navigate
+        to={`/auth?redirect=${encodeURIComponent(location.pathname)}`}
+        replace
+      />
+    );
   }
 
   return (

--- a/src/pages/Settings.tsx
+++ b/src/pages/Settings.tsx
@@ -6,11 +6,12 @@ import { Button } from "@/components/ui/button";
 import { Label } from "@/components/ui/label";
 import { Switch } from "@/components/ui/switch";
 import { Separator } from "@/components/ui/separator";
-import { Navigate } from "react-router-dom";
+import { Navigate, useLocation } from "react-router-dom";
 import { Moon, Sun, Bell, Shield, User } from "lucide-react";
 
 export default function Settings() {
   const { user, isAuthenticated } = useAuth();
+  const location = useLocation();
   const { theme, toggleTheme } = useTheme();
   const [notifications, setNotifications] = useState({
     email: true,
@@ -19,7 +20,12 @@ export default function Settings() {
   });
 
   if (!isAuthenticated) {
-    return <Navigate to="/auth" replace />;
+    return (
+      <Navigate
+        to={`/auth?redirect=${encodeURIComponent(location.pathname)}`}
+        replace
+      />
+    );
   }
 
   return (


### PR DESCRIPTION
## Summary
- use `useLocation` to retain the current pathname when redirecting unauthenticated users
- update redirects in Profile and Settings pages

## Testing
- `npm run lint` *(fails: many existing lint errors)*

------
https://chatgpt.com/codex/tasks/task_e_688527d2ccec832ea6b01a6b21b2f2ed