### PR TITLE
Add standalone admin panel skeleton

### DIFF
--- a/admin-panel/README.md
+++ b/admin-panel/README.md
@@ -1,0 +1,17 @@
+# Zwanski Admin Panel
+
+This directory contains a standalone admin panel for managing content on **zwanski.org**. It is a lightweight React + Vite application that connects directly to the existing Supabase backend.
+
+## Features
+
+- Secure login via Supabase authentication
+- Placeholder dashboard for future management tools (blog posts, services, courses, marketplace content, static pages, media uploads, and site settings)
+
+## Development
+
+```
+npm install
+npm run dev
+```
+
+The panel is intentionally separated from the main site so it can be deployed to a different route such as `admin.zwanski.org`.

--- a/admin-panel/index.html
+++ b/admin-panel/index.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Zwanski Admin Panel</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/main.tsx"></script>
+  </body>
+</html>

--- a/admin-panel/package.json
+++ b/admin-panel/package.json
@@ -1,0 +1,24 @@
+{
+  "name": "zwanski-admin-panel",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "dev": "vite",
+    "build": "vite build",
+    "preview": "vite preview"
+  },
+  "dependencies": {
+    "react": "^18.3.1",
+    "react-dom": "^18.3.1",
+    "@supabase/supabase-js": "^2.50.0",
+    "react-router-dom": "^6.26.2"
+  },
+  "devDependencies": {
+    "@types/react": "^18.3.3",
+    "@types/react-dom": "^18.3.0",
+    "typescript": "^5.5.3",
+    "@vitejs/plugin-react-swc": "^3.5.0",
+    "vite": "^5.4.19"
+  }
+}

--- a/admin-panel/src/App.tsx
+++ b/admin-panel/src/App.tsx
@@ -1,0 +1,21 @@
+import React from 'react';
+import { BrowserRouter, Routes, Route, Navigate } from 'react-router-dom';
+import Login from './pages/Login';
+import Dashboard from './pages/Dashboard';
+import { createClient } from '@supabase/supabase-js';
+
+const supabaseUrl = import.meta.env.VITE_SUPABASE_URL as string;
+const supabaseKey = import.meta.env.VITE_SUPABASE_ANON_KEY as string;
+export const supabase = createClient(supabaseUrl, supabaseKey);
+
+export default function App() {
+  return (
+    <BrowserRouter>
+      <Routes>
+        <Route path="/" element={<Navigate to="/login" replace />} />
+        <Route path="/login" element={<Login />} />
+        <Route path="/dashboard/*" element={<Dashboard />} />
+      </Routes>
+    </BrowserRouter>
+  );
+}

--- a/admin-panel/src/main.tsx
+++ b/admin-panel/src/main.tsx
@@ -1,0 +1,9 @@
+import React from 'react';
+import ReactDOM from 'react-dom/client';
+import App from './App';
+
+ReactDOM.createRoot(document.getElementById('root') as HTMLElement).render(
+  <React.StrictMode>
+    <App />
+  </React.StrictMode>
+);

--- a/admin-panel/src/pages/Dashboard.tsx
+++ b/admin-panel/src/pages/Dashboard.tsx
@@ -1,0 +1,36 @@
+import React, { useEffect, useState } from 'react';
+import { Routes, Route, Link, Navigate } from 'react-router-dom';
+import { supabase } from '../App';
+
+function ProtectedRoute({ children }: { children: JSX.Element }) {
+  const [loading, setLoading] = useState(true);
+  const [session, setSession] = useState<any>(null);
+
+  useEffect(() => {
+    supabase.auth.getSession().then(({ data }) => {
+      setSession(data.session);
+      setLoading(false);
+    });
+  }, []);
+
+  if (loading) return null;
+  if (!session) return <Navigate to="/login" replace />;
+  return children;
+}
+
+function Home() {
+  return <h2>Welcome to the Admin Dashboard</h2>;
+}
+
+export default function Dashboard() {
+  return (
+    <div style={{ padding: '1rem' }}>
+      <nav style={{ marginBottom: '1rem' }}>
+        <Link to="/dashboard">Home</Link>
+      </nav>
+      <Routes>
+        <Route index element={<ProtectedRoute><Home /></ProtectedRoute>} />
+      </Routes>
+    </div>
+  );
+}

--- a/admin-panel/src/pages/Login.tsx
+++ b/admin-panel/src/pages/Login.tsx
@@ -1,0 +1,44 @@
+import React, { useState } from 'react';
+import { supabase } from '../App';
+import { useNavigate } from 'react-router-dom';
+
+export default function Login() {
+  const [email, setEmail] = useState('');
+  const [password, setPassword] = useState('');
+  const [error, setError] = useState<string | null>(null);
+  const navigate = useNavigate();
+
+  const handleLogin = async (e: React.FormEvent) => {
+    e.preventDefault();
+    const { error } = await supabase.auth.signInWithPassword({ email, password });
+    if (error) {
+      setError(error.message);
+    } else {
+      navigate('/dashboard');
+    }
+  };
+
+  return (
+    <div style={{ display: 'flex', justifyContent: 'center', marginTop: '10%' }}>
+      <form onSubmit={handleLogin} style={{ display: 'flex', flexDirection: 'column', gap: '1rem' }}>
+        <h2>Admin Login</h2>
+        <input
+          type="email"
+          placeholder="Email"
+          value={email}
+          onChange={(e) => setEmail(e.target.value)}
+          required
+        />
+        <input
+          type="password"
+          placeholder="Password"
+          value={password}
+          onChange={(e) => setPassword(e.target.value)}
+          required
+        />
+        {error && <div style={{ color: 'red' }}>{error}</div>}
+        <button type="submit">Login</button>
+      </form>
+    </div>
+  );
+}

--- a/admin-panel/tsconfig.json
+++ b/admin-panel/tsconfig.json
@@ -1,0 +1,14 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "module": "ESNext",
+    "lib": ["DOM", "DOM.Iterable", "ES2020"],
+    "jsx": "react-jsx",
+    "moduleResolution": "bundler",
+    "strict": true,
+    "skipLibCheck": true,
+    "esModuleInterop": true,
+    "forceConsistentCasingInFileNames": true
+  },
+  "include": ["src"]
+}

--- a/admin-panel/vite.config.ts
+++ b/admin-panel/vite.config.ts
@@ -1,0 +1,17 @@
+import { defineConfig } from 'vite';
+import react from '@vitejs/plugin-react-swc';
+import path from 'path';
+
+export default defineConfig({
+  plugins: [react()],
+  resolve: {
+    alias: {
+      '@': path.resolve(__dirname, 'src'),
+    },
+  },
+  build: {
+    outDir: 'dist',
+    target: 'es2020'
+  },
+  base: './'
+});


### PR DESCRIPTION
## Summary
- scaffold a new `admin-panel` Vite+React app
- basic login page authenticates with Supabase
- minimal dashboard page behind auth check
- document how to develop the admin panel

## Testing
- `npm run lint` *(fails: 58 errors)*
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_688528e1f7dc832e95077a691e97bc72