### PR TITLE
Switch forms to Cloudflare Turnstile

### DIFF
--- a/src/components/Turnstile.tsx
+++ b/src/components/Turnstile.tsx
@@ -1,0 +1,87 @@
+import React, { useEffect, useRef } from "react";
+
+export interface TurnstileProps {
+  siteKey: string;
+  onVerify: (token: string) => void;
+  onError?: () => void;
+  onExpire?: () => void;
+}
+
+declare global {
+  interface Window {
+    turnstile?: {
+      render: (
+        container: string | HTMLElement,
+        options: Record<string, unknown>
+      ) => string;
+      remove: (widgetId: string) => void;
+    };
+  }
+}
+
+const Turnstile: React.FC<TurnstileProps> = ({
+  siteKey,
+  onVerify,
+  onError,
+  onExpire,
+}) => {
+  const widgetIdRef = useRef<string | null>(null);
+  const containerId = useRef(
+    `cf-turnstile-${Math.random().toString(36).slice(2)}`
+  );
+
+  useEffect(() => {
+    const loadScript = () => {
+      if (
+        document.querySelector(
+          "script[src='https://challenges.cloudflare.com/turnstile/v0/api.js']"
+        )
+      ) {
+        renderWidget();
+        return;
+      }
+
+      const script = document.createElement("script");
+      script.src =
+        "https://challenges.cloudflare.com/turnstile/v0/api.js";
+      script.async = true;
+      script.onload = renderWidget;
+      script.onerror = () => onError?.();
+      document.body.appendChild(script);
+    };
+
+    const renderWidget = () => {
+      if (!window.turnstile) {
+        setTimeout(renderWidget, 200);
+        return;
+      }
+
+      try {
+        widgetIdRef.current = window.turnstile!.render(
+          `#${containerId.current}`,
+          {
+            sitekey: siteKey,
+            callback: (token: string) => onVerify(token),
+            "error-callback": onError,
+            "expired-callback": onExpire,
+          }
+        );
+      } catch {
+        onError?.();
+      }
+    };
+
+    loadScript();
+
+    return () => {
+      if (widgetIdRef.current && window.turnstile) {
+        window.turnstile.remove(widgetIdRef.current);
+        widgetIdRef.current = null;
+      }
+    };
+  }, [siteKey, onVerify, onError, onExpire]);
+
+  return <div id={containerId.current} className="cf-turnstile" />;
+};
+
+export default Turnstile;

--- a/src/lib/logTurnstile.ts
+++ b/src/lib/logTurnstile.ts
@@ -1,0 +1,16 @@
+import { supabase } from '@/integrations/supabase/client';
+import { TurnstileVerifyResponse } from './verifyTurnstile';
+
+export async function logTurnstile(token: string, result: TurnstileVerifyResponse) {
+  try {
+    await supabase.from('turnstile_logs').insert({
+      token,
+      success: result.success,
+      errors: result['error-codes'] || null,
+      hostname: result.hostname || null,
+      challenge_ts: result.challenge_ts || null
+    });
+  } catch (error) {
+    console.warn('Failed to log Turnstile result', error);
+  }
+}

--- a/src/lib/verifyTurnstile.ts
+++ b/src/lib/verifyTurnstile.ts
@@ -1,0 +1,28 @@
+export interface TurnstileVerifyResponse {
+  success: boolean;
+  'error-codes'?: string[];
+  challenge_ts?: string;
+  hostname?: string;
+}
+
+export async function verifyTurnstile(token: string): Promise<TurnstileVerifyResponse> {
+  const secret = import.meta.env.VITE_CF_TURNSTILE_SECRET;
+  if (!secret) {
+    throw new Error('CF_TURNSTILE_SECRET not set');
+  }
+
+  const formData = new FormData();
+  formData.append('secret', secret);
+  formData.append('response', token);
+
+  const res = await fetch('https://challenges.cloudflare.com/turnstile/v0/siteverify', {
+    method: 'POST',
+    body: formData
+  });
+
+  if (!res.ok) {
+    throw new Error(`Verification request failed: ${res.status}`);
+  }
+
+  return res.json() as Promise<TurnstileVerifyResponse>;
+}


### PR DESCRIPTION
## Summary
- add Turnstile widget component and verification helpers
- log Turnstile results in Supabase
- replace hCaptcha usage in Contact, EnhancedContact and Auth pages

## Testing
- `npm run lint` *(fails: several lint errors)*

------
https://chatgpt.com/codex/tasks/task_e_68856c55bcb0832e8107b96d67424973