### PR TITLE
Fix README clone command

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ Welcome to the Zwanski Tech platform! This project powers [zwanski.org](https://
 ## 🏁 Getting Started
 
 ```bash
-git clone https://https://github.com/zwanski2019/ZWANSKI-TECH.git
+git clone https://github.com/zwanski2019/ZWANSKI-TECH.git
 cd ZWANSKI-TECH
 npm install
 npm run dev


### PR DESCRIPTION
## Summary
- fix the duplicate `https://` in the README clone command

## Testing
- no tests run because only documentation was modified

------
https://chatgpt.com/codex/tasks/task_e_6885778aaad8832eada8efd26226c2f1