### PR TITLE
Add Contact page with map and nav link

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -65,6 +65,7 @@ const IMEICheck = lazy(() => import("./pages/IMEICheck"));
 const Infrastructure = lazy(() => import("./pages/Infrastructure"));
 const Tools = lazy(() => import("./pages/Tools"));
 const Blog = lazy(() => import("./pages/Blog"));
+const ContactPage = lazy(() => import("./pages/Contact"));
 const RSS = lazy(() => import("./pages/RSS"));
 const Search = lazy(() => import("./pages/Search"));
 const AIAssistantPage = lazy(() => import("./pages/ai"));
@@ -163,8 +164,9 @@ function App() {
                            <Route path="/login" element={<Auth />} />
                            <Route path="/register" element={<Auth />} />
                            <Route path="/signup" element={<Auth />} />
-                           <Route path="/blog" element={<Blog />} />
-                          
+                          <Route path="/blog" element={<Blog />} />
+                          <Route path="/contact" element={<ContactPage />} />
+
                           {/* Admin Routes */}
                           <Route path="/admin" element={<AdminDashboard />} />
                           <Route path="/admin/users" element={<AdminUsers />} />

--- a/src/components/Navbar.tsx
+++ b/src/components/Navbar.tsx
@@ -13,6 +13,7 @@ import {
   Settings2,
   FileText,
   MessageSquare,
+  Mail,
   Bot,
   Activity
 } from "lucide-react";
@@ -128,6 +129,7 @@ const Navbar = () => {
     { label: "Jobs", path: "/jobs", icon: Briefcase },
     { label: "Blog", path: "/blog", icon: FileText },
     { label: "Chat", path: "/chat", icon: MessageSquare },
+    { label: "Contact", path: "/contact", icon: Mail },
     { label: "Threat Map", path: "/threat-map", icon: Activity },
     { label: "AI", path: "/ai", icon: Bot },
   ];

--- a/src/components/navbar/DesktopNavigation.tsx
+++ b/src/components/navbar/DesktopNavigation.tsx
@@ -14,6 +14,7 @@ const navItems = [
   { label: "Chat", path: "/chat", icon: MessageSquare },
   { label: "Newsletter", path: "/newsletter", icon: Mail },
   { label: "Tools", path: "/tools", icon: Settings },
+  { label: "Contact", path: "/contact", icon: Mail },
   { label: "3D Model", path: "/3d", icon: BookOpen },
   { label: "About", path: "/about", icon: Info },
   { label: "FAQ", path: "/faq", icon: FileText },

--- a/src/components/navbar/MobileNavigation.tsx
+++ b/src/components/navbar/MobileNavigation.tsx
@@ -14,6 +14,7 @@ const navItems = [
   { label: "Chat", path: "/chat", icon: MessageSquare },
   { label: "Newsletter", path: "/newsletter", icon: Mail },
   { label: "Tools", path: "/tools", icon: Settings },
+  { label: "Contact", path: "/contact", icon: Mail },
   { label: "3D Model", path: "/3d", icon: BookOpen },
   { label: "About", path: "/about", icon: Info },
   { label: "FAQ", path: "/faq", icon: FileText },

--- a/src/pages/Contact.tsx
+++ b/src/pages/Contact.tsx
@@ -1,0 +1,40 @@
+import React from "react";
+import { Helmet } from "react-helmet-async";
+import Navbar from "@/components/Navbar";
+import Footer from "@/components/Footer";
+import EnhancedContact from "@/components/EnhancedContact";
+
+export default function Contact() {
+  return (
+    <>
+      <Helmet>
+        <title>Contact Us - Zwanski Tech</title>
+        <meta
+          name="description"
+          content="Get in touch with Zwanski Tech for services, inquiries or support."
+        />
+      </Helmet>
+      <div className="flex flex-col min-h-screen bg-background">
+        <Navbar />
+        <main className="flex-grow">
+          <section className="py-16">
+            <div className="container mx-auto px-4 space-y-10">
+              <EnhancedContact />
+              <div className="relative w-full" style={{ paddingBottom: "56.25%" }}>
+                <iframe
+                  src="https://www.google.com/maps/embed?pb=!1m18!1m12!1m3!1d3310.7178757754437!2d10.16579!3d36.806495!2m3!1f0!2f0!3f0!3m2!1i1024!2i768!4f13.1!3m3!1m2!1s0x12fd34a2bf7ceef1%3A0x1c1b4a93a8f8e741!2sTunis%2C%20Tunisia!5e0!3m2!1sen!2stn!4v1717937045032!5m2!1sen!2stn"
+                  title="Zwanski Tech Location Map"
+                  aria-label="Map showing Zwanski Tech location"
+                  className="absolute top-0 left-0 w-full h-full rounded-lg border-none"
+                  loading="lazy"
+                  referrerPolicy="no-referrer-when-downgrade"
+                />
+              </div>
+            </div>
+          </section>
+        </main>
+        <Footer />
+      </div>
+    </>
+  );
+}


### PR DESCRIPTION
## Summary
- create `Contact` page with Google Map embed
- register `/contact` route in the app router
- link to Contact page from desktop and mobile nav
- add icon import for new nav item

## Testing
- `npm run lint` *(fails: unexpected any in existing files)*
- `npm test` *(fails: missing script)*

------
https://chatgpt.com/codex/tasks/task_e_68857785be7c832e94c30d4cd1fa5710