### PR TITLE
Switch pages to SEOHelmet component

### DIFF
--- a/src/pages/About.tsx
+++ b/src/pages/About.tsx
@@ -1,5 +1,5 @@
 
-import { Helmet } from "react-helmet-async";
+import { SEOHelmet } from "@/components/SEOHelmet";
 import { useLanguage } from "@/context/LanguageContext";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Badge } from "@/components/ui/badge";
@@ -40,10 +40,11 @@ export default function About() {
 
   return (
     <>
-      <Helmet>
-        <title>About Us - Zwanski Tech</title>
-        <meta name="description" content="Learn about Zwanski Tech's mission to provide free tech education and quality development services worldwide." />
-      </Helmet>
+      <SEOHelmet
+        title="About Us - Zwanski Tech"
+        description="Learn about Zwanski Tech's mission to provide free tech education and quality development services worldwide."
+        canonical="https://zwanski.org/about"
+      />
 
       <div className="flex flex-col min-h-screen bg-background">
         <Navbar />

--- a/src/pages/FAQ.tsx
+++ b/src/pages/FAQ.tsx
@@ -1,5 +1,5 @@
 
-import { Helmet } from "react-helmet-async";
+import { SEOHelmet } from "@/components/SEOHelmet";
 import { useLanguage } from "@/context/LanguageContext";
 import { 
   Accordion,
@@ -118,10 +118,11 @@ export default function FAQ() {
 
   return (
     <>
-      <Helmet>
-        <title>Frequently Asked Questions - Zwanski Tech</title>
-        <meta name="description" content="Find answers to common questions about Zwanski Tech services, academy, job marketplace, and technical support." />
-      </Helmet>
+      <SEOHelmet
+        title="Frequently Asked Questions - Zwanski Tech"
+        description="Find answers to common questions about Zwanski Tech services, academy, job marketplace, and technical support."
+        canonical="https://zwanski.org/faq"
+      />
 
       <div className="flex flex-col min-h-screen bg-background">
         <Navbar />

--- a/src/pages/Newsletter.tsx
+++ b/src/pages/Newsletter.tsx
@@ -1,6 +1,6 @@
 
 import React from "react";
-import { Helmet } from "react-helmet-async";
+import { SEOHelmet } from "@/components/SEOHelmet";
 import Navbar from "../components/Navbar";
 import Footer from "../components/Footer";
 import NewsletterForm from "../components/NewsletterForm";
@@ -9,13 +9,11 @@ import { Sparkles, Stars, Wand2 } from "lucide-react";
 export default function Newsletter() {
   return (
     <>
-      <Helmet>
-        <title>Magic Newsletter - Join the Enchantment</title>
-        <meta
-          name="description"
-          content="Join our magical newsletter and stay updated with the latest enchanted developments and spellbinding news."
-        />
-      </Helmet>
+      <SEOHelmet
+        title="Magic Newsletter - Join the Enchantment"
+        description="Join our magical newsletter and stay updated with the latest enchanted developments and spellbinding news."
+        canonical="https://zwanski.org/newsletter"
+      />
 
       <div className="min-h-screen flex flex-col bg-background">
         <Navbar />

--- a/src/pages/PrivacyPolicy.tsx
+++ b/src/pages/PrivacyPolicy.tsx
@@ -1,5 +1,5 @@
 
-import { Helmet } from "react-helmet-async";
+import { SEOHelmet } from "@/components/SEOHelmet";
 import { useLanguage } from "@/context/LanguageContext";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Shield, Eye, Cookie, Database, Mail } from "lucide-react";
@@ -11,10 +11,11 @@ export default function PrivacyPolicy() {
 
   return (
     <>
-      <Helmet>
-        <title>Privacy Policy - Zwanski Tech</title>
-        <meta name="description" content="Learn how Zwanski Tech protects your privacy and handles your personal data." />
-      </Helmet>
+      <SEOHelmet
+        title="Privacy Policy - Zwanski Tech"
+        description="Learn how Zwanski Tech protects your privacy and handles your personal data."
+        canonical="https://zwanski.org/privacy-policy"
+      />
 
       <div className="flex flex-col min-h-screen">
         <Navbar />

--- a/src/pages/Support.tsx
+++ b/src/pages/Support.tsx
@@ -4,19 +4,17 @@ import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import Navbar from "@/components/Navbar";
 import Footer from "@/components/Footer";
-import { Helmet } from "react-helmet-async";
+import { SEOHelmet } from "@/components/SEOHelmet";
 
 const Support = () => {
   return (
     <div className="flex flex-col min-h-screen bg-background">
-      <Helmet>
-        <title>Support Zwanski Tech - Keep Our Services Free</title>
-        <meta 
-          name="description" 
-          content="Learn how you can support Zwanski Tech and help us keep our courses, tools, and services completely free for everyone."
-        />
-      </Helmet>
-      
+      <SEOHelmet
+        title="Support Zwanski Tech - Keep Our Services Free"
+        description="Learn how you can support Zwanski Tech and help us keep our courses, tools, and services completely free for everyone."
+        canonical="https://zwanski.org/support"
+      />
+
       <Navbar />
       
       <main className="flex-grow axeptio-section">

--- a/src/pages/TermsOfService.tsx
+++ b/src/pages/TermsOfService.tsx
@@ -1,5 +1,5 @@
 
-import { Helmet } from "react-helmet-async";
+import { SEOHelmet } from "@/components/SEOHelmet";
 import { useLanguage } from "@/context/LanguageContext";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { FileText, Users, Shield, AlertTriangle, Gavel } from "lucide-react";
@@ -11,10 +11,11 @@ export default function TermsOfService() {
 
   return (
     <>
-      <Helmet>
-        <title>Terms of Service - Zwanski Tech</title>
-        <meta name="description" content="Terms and conditions for using Zwanski Tech services and platform." />
-      </Helmet>
+      <SEOHelmet
+        title="Terms of Service - Zwanski Tech"
+        description="Terms and conditions for using Zwanski Tech services and platform."
+        canonical="https://zwanski.org/terms-of-service"
+      />
 
       <div className="flex flex-col min-h-screen">
         <Navbar />

--- a/src/pages/Tools.tsx
+++ b/src/pages/Tools.tsx
@@ -1,4 +1,4 @@
-import { Helmet } from "react-helmet-async";
+import { SEOHelmet } from "@/components/SEOHelmet";
 import Navbar from "@/components/Navbar";
 import Footer from "@/components/Footer";
 import IMEIChecker from "@/components/IMEIChecker";
@@ -85,11 +85,11 @@ const Tools = () => {
 
   return (
     <>
-      <Helmet>
-        <title>Free Tools - ZWANSKI TECH</title>
-        <meta name="description" content="Free online tools including IMEI checker, password generator, QR code generator and more. Professional utility tools for developers and users." />
-        <meta name="keywords" content="free tools, IMEI checker, password generator, QR code, online tools, utilities" />
-      </Helmet>
+      <SEOHelmet
+        title="Free Tools - ZWANSKI TECH"
+        description="Free online tools including IMEI checker, password generator, QR code generator and more. Professional utility tools for developers and users."
+        canonical="https://zwanski.org/tools"
+      />
       
       <div className="flex flex-col min-h-screen">
         <Navbar />


### PR DESCRIPTION
## Summary
- replace local Helmet blocks with SEOHelmet
- add canonical info for each page

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_688577853788832e960294f2ffb230e0