### PR TITLE
Add web manifest for PWA support

### DIFF
--- a/index.html
+++ b/index.html
@@ -23,7 +23,8 @@
     <meta name="twitter:image" content="https://zwanski.org/og-image.png" />
     <link rel="icon" href="/favicon-professional.svg" type="image/svg+xml">
     <link rel="icon" href="/favicon.png" type="image/png">
-    
+    <link rel="manifest" href="/manifest.json">
+
     <link rel="apple-touch-icon" href="/favicon-professional.svg">
     
     <!-- Security Headers -->

--- a/public/manifest.json
+++ b/public/manifest.json
@@ -1,0 +1,25 @@
+{
+  "name": "Zwanski Tech",
+  "short_name": "Zwanski",
+  "start_url": "/",
+  "display": "standalone",
+  "theme_color": "#ffffff",
+  "background_color": "#ffffff",
+  "icons": [
+    {
+      "src": "/favicon.png",
+      "sizes": "192x192",
+      "type": "image/png"
+    },
+    {
+      "src": "/favicon.png",
+      "sizes": "512x512",
+      "type": "image/png"
+    },
+    {
+      "src": "/favicon-professional.svg",
+      "sizes": "any",
+      "type": "image/svg+xml"
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
- create `public/manifest.json` with app metadata and icons
- link manifest in `index.html`

## Testing
- `npm run lint` *(fails: Cannot specify explicit any / etc.)*
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_68857fd73310832ea80b01c5d8e147c5