### PR TITLE
Accessibility tweaks

### DIFF
--- a/src/components/CookieConsent.tsx
+++ b/src/components/CookieConsent.tsx
@@ -68,7 +68,7 @@ export const CookieConsent: React.FC = () => {
       
       <Sheet open={showSheet} onOpenChange={setShowSheet}>
         <SheetTrigger asChild>
-          <button className="hidden" />
+          <button className="hidden" aria-label="Open cookie settings" />
         </SheetTrigger>
         <SheetContent className="sm:max-w-md">
           <SheetHeader className="space-y-3">

--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -151,9 +151,13 @@ const Index = () => {
             structuredData={structuredDataItems}
           />
           
-          <div className="min-h-screen bg-background text-foreground homepage-content" style={{opacity: 1, visibility: 'visible', display: 'block'}}>
-        <main className="flex flex-col min-h-screen">
-        <Navbar />
+          <main
+            id="main-content"
+            className="min-h-screen bg-background text-foreground homepage-content"
+            style={{ opacity: 1, visibility: 'visible', display: 'block' }}
+          >
+        <div className="flex flex-col min-h-screen">
+          <Navbar />
         
         {/* Hero Section */}
         <section className="animate-on-scroll">
@@ -413,8 +417,8 @@ const Index = () => {
         </section>
 
             <Footer />
-        </main>
-          </div>
+        </div>
+          </main>
         </>
       );
     } catch (error) {


### PR DESCRIPTION
## Summary
- replace homepage wrapper `<div>` with a `<main>` element
- expose an accessible label on cookie settings trigger

## Testing
- `npm run lint` *(fails: @typescript-eslint errors)*
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_688584d10f90832e9e9a9c063156aa9a