### PR TITLE
Add AI utilities dashboard with secure API integrations

### DIFF
--- a/src/components/CVGenerator.tsx
+++ b/src/components/CVGenerator.tsx
@@ -1,0 +1,62 @@
+import { useState } from "react";
+import { supabase } from "@/integrations/supabase/client";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Button } from "@/components/ui/button";
+import { Textarea } from "@/components/ui/textarea";
+import { Loader2 } from "lucide-react";
+
+export default function CVGenerator() {
+  const [input, setInput] = useState("");
+  const [result, setResult] = useState("");
+  const [loading, setLoading] = useState(false);
+
+  async function handleSubmit(e: React.FormEvent) {
+    e.preventDefault();
+    setLoading(true);
+    setResult("");
+    try {
+      const { data, error } = await supabase.functions.invoke("chatgpt-tools", {
+        body: { tool: "cv", prompt: input },
+      });
+      if (error) throw error;
+      setResult(data.result || "No response received.");
+    } catch (err) {
+      setResult("Failed to generate CV. Please try again.");
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  return (
+    <Card className="w-full">
+      <CardHeader>
+        <CardTitle>CV Generator</CardTitle>
+      </CardHeader>
+      <CardContent className="space-y-4">
+        <form onSubmit={handleSubmit} className="space-y-3">
+          <div>
+            <label className="block mb-1 text-sm font-medium" htmlFor="cv-input">
+              Career Details
+            </label>
+            <Textarea
+              id="cv-input"
+              value={input}
+              onChange={(e) => setInput(e.target.value)}
+              placeholder="Describe your skills and experience"
+              rows={5}
+            />
+          </div>
+          <Button type="submit" disabled={loading} className="flex items-center">
+            {loading && <Loader2 className="mr-2 h-4 w-4 animate-spin" />}
+            {loading ? "Generating..." : "Generate"}
+          </Button>
+        </form>
+        {result && (
+          <div className="prose max-w-none bg-muted/50 p-4 rounded" aria-live="polite">
+            {result}
+          </div>
+        )}
+      </CardContent>
+    </Card>
+  );
+}

--- a/src/components/MentalHealthBot.tsx
+++ b/src/components/MentalHealthBot.tsx
@@ -1,0 +1,62 @@
+import { useState } from "react";
+import { supabase } from "@/integrations/supabase/client";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Button } from "@/components/ui/button";
+import { Textarea } from "@/components/ui/textarea";
+import { Loader2 } from "lucide-react";
+
+export default function MentalHealthBot() {
+  const [prompt, setPrompt] = useState("");
+  const [result, setResult] = useState("");
+  const [loading, setLoading] = useState(false);
+
+  async function handleSubmit(e: React.FormEvent) {
+    e.preventDefault();
+    setLoading(true);
+    setResult("");
+    try {
+      const { data, error } = await supabase.functions.invoke("chatgpt-tools", {
+        body: { tool: "mental", prompt },
+      });
+      if (error) throw error;
+      setResult(data.result || "No response received.");
+    } catch (err) {
+      setResult("Failed to generate a response. Please try again.");
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  return (
+    <Card className="w-full">
+      <CardHeader>
+        <CardTitle>Mental Health Bot</CardTitle>
+      </CardHeader>
+      <CardContent className="space-y-4">
+        <form onSubmit={handleSubmit} className="space-y-3">
+          <div>
+            <label className="block mb-1 text-sm font-medium" htmlFor="mental-prompt">
+              How can I help you?
+            </label>
+            <Textarea
+              id="mental-prompt"
+              value={prompt}
+              onChange={(e) => setPrompt(e.target.value)}
+              placeholder="Share your thoughts..."
+              rows={4}
+            />
+          </div>
+          <Button type="submit" disabled={loading} className="flex items-center">
+            {loading && <Loader2 className="mr-2 h-4 w-4 animate-spin" />}
+            {loading ? "Sending..." : "Send"}
+          </Button>
+        </form>
+        {result && (
+          <div className="prose max-w-none bg-muted/50 p-4 rounded" aria-live="polite">
+            {result}
+          </div>
+        )}
+      </CardContent>
+    </Card>
+  );
+}

--- a/src/components/NewsGenerator.tsx
+++ b/src/components/NewsGenerator.tsx
@@ -1,0 +1,62 @@
+import { useState } from "react";
+import { supabase } from "@/integrations/supabase/client";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Button } from "@/components/ui/button";
+import { Textarea } from "@/components/ui/textarea";
+import { Loader2 } from "lucide-react";
+
+export default function NewsGenerator() {
+  const [topic, setTopic] = useState("");
+  const [result, setResult] = useState("");
+  const [loading, setLoading] = useState(false);
+
+  async function handleSubmit(e: React.FormEvent) {
+    e.preventDefault();
+    setLoading(true);
+    setResult("");
+    try {
+      const { data, error } = await supabase.functions.invoke("gemini-tools", {
+        body: { prompt: topic },
+      });
+      if (error) throw error;
+      setResult(data.result || "No response received.");
+    } catch (err) {
+      setResult("Failed to generate news. Please try again.");
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  return (
+    <Card className="w-full">
+      <CardHeader>
+        <CardTitle>News Generator</CardTitle>
+      </CardHeader>
+      <CardContent className="space-y-4">
+        <form onSubmit={handleSubmit} className="space-y-3">
+          <div>
+            <label className="block mb-1 text-sm font-medium" htmlFor="news-topic">
+              Topic
+            </label>
+            <Textarea
+              id="news-topic"
+              value={topic}
+              onChange={(e) => setTopic(e.target.value)}
+              placeholder="Enter a topic or keyword"
+              rows={3}
+            />
+          </div>
+          <Button type="submit" disabled={loading} className="flex items-center">
+            {loading && <Loader2 className="mr-2 h-4 w-4 animate-spin" />}
+            {loading ? "Generating..." : "Generate"}
+          </Button>
+        </form>
+        {result && (
+          <div className="prose max-w-none bg-muted/50 p-4 rounded" aria-live="polite">
+            {result}
+          </div>
+        )}
+      </CardContent>
+    </Card>
+  );
+}

--- a/src/components/SEOScanner.tsx
+++ b/src/components/SEOScanner.tsx
@@ -1,0 +1,61 @@
+import { useState } from "react";
+import { supabase } from "@/integrations/supabase/client";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Loader2 } from "lucide-react";
+
+export default function SEOScanner() {
+  const [url, setUrl] = useState("");
+  const [result, setResult] = useState("");
+  const [loading, setLoading] = useState(false);
+
+  async function handleSubmit(e: React.FormEvent) {
+    e.preventDefault();
+    setLoading(true);
+    setResult("");
+    try {
+      const { data, error } = await supabase.functions.invoke("chatgpt-tools", {
+        body: { tool: "seo", prompt: url },
+      });
+      if (error) throw error;
+      setResult(data.result || "No response received.");
+    } catch (err) {
+      setResult("Failed to scan URL. Please try again.");
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  return (
+    <Card className="w-full">
+      <CardHeader>
+        <CardTitle>SEO Scanner</CardTitle>
+      </CardHeader>
+      <CardContent className="space-y-4">
+        <form onSubmit={handleSubmit} className="space-y-3">
+          <div>
+            <label className="block mb-1 text-sm font-medium" htmlFor="seo-url">
+              Website URL
+            </label>
+            <Input
+              id="seo-url"
+              value={url}
+              onChange={(e) => setUrl(e.target.value)}
+              placeholder="https://example.com"
+            />
+          </div>
+          <Button type="submit" disabled={loading} className="flex items-center">
+            {loading && <Loader2 className="mr-2 h-4 w-4 animate-spin" />}
+            {loading ? "Scanning..." : "Scan"}
+          </Button>
+        </form>
+        {result && (
+          <div className="prose max-w-none bg-muted/50 p-4 rounded" aria-live="polite">
+            {result}
+          </div>
+        )}
+      </CardContent>
+    </Card>
+  );
+}

--- a/src/pages/ai.tsx
+++ b/src/pages/ai.tsx
@@ -1,24 +1,56 @@
-import GPTAssistant from "@/components/GPTAssistant";
-import { Button } from "@/components/ui/button";
 import { ArrowLeft } from "lucide-react";
 import { useNavigate } from "react-router-dom";
+import Navbar from "@/components/Navbar";
+import Footer from "@/components/Footer";
+import { SEOHelmet } from "@/components/SEOHelmet";
+import { Button } from "@/components/ui/button";
+import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
+import CVGenerator from "@/components/CVGenerator";
+import NewsGenerator from "@/components/NewsGenerator";
+import SEOScanner from "@/components/SEOScanner";
+import MentalHealthBot from "@/components/MentalHealthBot";
 
-export default function AIAssistantPage() {
+export default function AIDashboardPage() {
   const navigate = useNavigate();
 
   return (
-    <div className="container mx-auto px-4">
-      <div className="mt-4 mb-2">
+    <div className="flex flex-col min-h-screen">
+      <SEOHelmet
+        title="AI Utilities - Zwanski Tech"
+        description="Dashboard of helpful AI tools including CV generator, news creator and more."
+        canonical="https://zwanski.org/ai"
+      />
+      <Navbar />
+      <main className="flex-grow container mx-auto px-4 py-8">
         <Button
           variant="ghost"
           onClick={() => navigate("/")}
-          className="gap-1"
+          className="gap-1 mb-4"
         >
-          <ArrowLeft className="h-4 w-4" />
-          Home
+          <ArrowLeft className="h-4 w-4" /> Home
         </Button>
-      </div>
-      <GPTAssistant />
+        <Tabs defaultValue="cv" className="w-full">
+          <TabsList className="grid w-full grid-cols-4">
+            <TabsTrigger value="cv">CV Generator</TabsTrigger>
+            <TabsTrigger value="news">News</TabsTrigger>
+            <TabsTrigger value="seo">SEO Scanner</TabsTrigger>
+            <TabsTrigger value="mental">Mental Health</TabsTrigger>
+          </TabsList>
+          <TabsContent value="cv" className="mt-6">
+            <CVGenerator />
+          </TabsContent>
+          <TabsContent value="news" className="mt-6">
+            <NewsGenerator />
+          </TabsContent>
+          <TabsContent value="seo" className="mt-6">
+            <SEOScanner />
+          </TabsContent>
+          <TabsContent value="mental" className="mt-6">
+            <MentalHealthBot />
+          </TabsContent>
+        </Tabs>
+      </main>
+      <Footer />
     </div>
   );
 }

--- a/supabase/functions/chatgpt-tools/index.ts
+++ b/supabase/functions/chatgpt-tools/index.ts
@@ -1,0 +1,73 @@
+import { serve } from "https://deno.land/std@0.190.0/http/server.ts";
+
+const corsHeaders = {
+  "Access-Control-Allow-Origin": "*",
+  "Access-Control-Allow-Headers": "authorization, x-client-info, apikey, content-type",
+};
+
+serve(async (req) => {
+  if (req.method === "OPTIONS") {
+    return new Response(null, { headers: corsHeaders });
+  }
+
+  try {
+    const { prompt, tool } = await req.json();
+    if (!prompt) {
+      return new Response(
+        JSON.stringify({ error: "Prompt is required" }),
+        { status: 400, headers: { ...corsHeaders, "Content-Type": "application/json" } }
+      );
+    }
+
+    const OPENAI_API_KEY = Deno.env.get("OPENAI_API_KEY");
+    if (!OPENAI_API_KEY) {
+      return new Response(
+        JSON.stringify({ error: "Server configuration error" }),
+        { status: 500, headers: { ...corsHeaders, "Content-Type": "application/json" } }
+      );
+    }
+
+    const messages = [
+      { role: "system", content: "You are a helpful assistant." },
+      { role: "user", content: prompt },
+    ];
+
+    if (tool === "cv") {
+      messages.unshift({ role: "system", content: "Generate a concise professional CV based on the user input." });
+    } else if (tool === "seo") {
+      messages.unshift({ role: "system", content: "Act as an SEO expert and analyse the provided text." });
+    } else if (tool === "mental") {
+      messages.unshift({ role: "system", content: "Provide supportive mental health advice." });
+    }
+
+    const response = await fetch("https://api.openai.com/v1/chat/completions", {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        Authorization: `Bearer ${OPENAI_API_KEY}`,
+      },
+      body: JSON.stringify({
+        model: "gpt-3.5-turbo",
+        messages,
+      }),
+    });
+
+    if (!response.ok) {
+      throw new Error(`OpenAI API error: ${response.status}`);
+    }
+
+    const result = await response.json();
+    const answer = result.choices?.[0]?.message?.content || "";
+
+    return new Response(
+      JSON.stringify({ result: answer }),
+      { headers: { ...corsHeaders, "Content-Type": "application/json" } }
+    );
+  } catch (err) {
+    console.error("chatgpt-tools error", err);
+    return new Response(
+      JSON.stringify({ error: "Internal server error" }),
+      { status: 500, headers: { ...corsHeaders, "Content-Type": "application/json" } }
+    );
+  }
+});

--- a/supabase/functions/cloudinary-upload/index.ts
+++ b/supabase/functions/cloudinary-upload/index.ts
@@ -1,0 +1,56 @@
+import { serve } from "https://deno.land/std@0.190.0/http/server.ts";
+
+const corsHeaders = {
+  "Access-Control-Allow-Origin": "*",
+  "Access-Control-Allow-Headers": "authorization, x-client-info, apikey, content-type",
+};
+
+serve(async (req) => {
+  if (req.method === "OPTIONS") {
+    return new Response(null, { headers: corsHeaders });
+  }
+
+  try {
+    const formData = await req.formData();
+    const file = formData.get("file");
+    if (!(file instanceof File)) {
+      return new Response(
+        JSON.stringify({ error: "File is required" }),
+        { status: 400, headers: { ...corsHeaders, "Content-Type": "application/json" } }
+      );
+    }
+
+    const CLOUDINARY_CLOUD_NAME = Deno.env.get("CLOUDINARY_CLOUD_NAME");
+    const CLOUDINARY_UPLOAD_PRESET = Deno.env.get("CLOUDINARY_UPLOAD_PRESET");
+
+    if (!CLOUDINARY_CLOUD_NAME || !CLOUDINARY_UPLOAD_PRESET) {
+      return new Response(
+        JSON.stringify({ error: "Server configuration error" }),
+        { status: 500, headers: { ...corsHeaders, "Content-Type": "application/json" } }
+      );
+    }
+
+    const uploadUrl = `https://api.cloudinary.com/v1_1/${CLOUDINARY_CLOUD_NAME}/image/upload`;
+    const uploadData = new FormData();
+    uploadData.append("file", file);
+    uploadData.append("upload_preset", CLOUDINARY_UPLOAD_PRESET);
+
+    const uploadRes = await fetch(uploadUrl, { method: "POST", body: uploadData });
+    if (!uploadRes.ok) {
+      throw new Error(`Cloudinary upload failed: ${uploadRes.status}`);
+    }
+
+    const result = await uploadRes.json();
+
+    return new Response(
+      JSON.stringify({ url: result.secure_url }),
+      { headers: { ...corsHeaders, "Content-Type": "application/json" } }
+    );
+  } catch (err) {
+    console.error("cloudinary-upload error", err);
+    return new Response(
+      JSON.stringify({ error: "Internal server error" }),
+      { status: 500, headers: { ...corsHeaders, "Content-Type": "application/json" } }
+    );
+  }
+});

--- a/supabase/functions/gemini-tools/index.ts
+++ b/supabase/functions/gemini-tools/index.ts
@@ -1,0 +1,58 @@
+import { serve } from "https://deno.land/std@0.190.0/http/server.ts";
+
+const corsHeaders = {
+  "Access-Control-Allow-Origin": "*",
+  "Access-Control-Allow-Headers": "authorization, x-client-info, apikey, content-type",
+};
+
+serve(async (req) => {
+  if (req.method === "OPTIONS") {
+    return new Response(null, { headers: corsHeaders });
+  }
+
+  try {
+    const { prompt } = await req.json();
+    if (!prompt) {
+      return new Response(
+        JSON.stringify({ error: "Prompt is required" }),
+        { status: 400, headers: { ...corsHeaders, "Content-Type": "application/json" } }
+      );
+    }
+
+    const GEMINI_API_KEY = Deno.env.get("GEMINI_API_KEY");
+    if (!GEMINI_API_KEY) {
+      return new Response(
+        JSON.stringify({ error: "Server configuration error" }),
+        { status: 500, headers: { ...corsHeaders, "Content-Type": "application/json" } }
+      );
+    }
+
+    const endpoint = `https://generativelanguage.googleapis.com/v1beta/models/gemini-pro:generateContent?key=${GEMINI_API_KEY}`;
+
+    const response = await fetch(endpoint, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        contents: [{ parts: [{ text: prompt }] }],
+      }),
+    });
+
+    if (!response.ok) {
+      throw new Error(`Gemini API error: ${response.status}`);
+    }
+
+    const result = await response.json();
+    const answer = result.candidates?.[0]?.content?.parts?.[0]?.text || "";
+
+    return new Response(
+      JSON.stringify({ result: answer }),
+      { headers: { ...corsHeaders, "Content-Type": "application/json" } }
+    );
+  } catch (err) {
+    console.error("gemini-tools error", err);
+    return new Response(
+      JSON.stringify({ error: "Internal server error" }),
+      { status: 500, headers: { ...corsHeaders, "Content-Type": "application/json" } }
+    );
+  }
+});


### PR DESCRIPTION
## Summary
- implement new AI dashboard page with tabs for multiple utilities
- add CV, news, SEO scanner, and mental health components
- add Supabase edge functions for ChatGPT, Gemini, and Cloudinary

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6885945abff8832ea80c7d2e7b2469b1