### PR TITLE
Enable guest course enrollments

### DIFF
--- a/src/components/academy/CourseCard.tsx
+++ b/src/components/academy/CourseCard.tsx
@@ -60,15 +60,26 @@ const CourseCard = ({ course, isEnrolled, viewMode }: CourseCardProps) => {
 
   const enrollMutation = useMutation({
     mutationFn: async () => {
-      if (!user) throw new Error("Please log in to enroll");
-      
+      if (!user) {
+        const stored = JSON.parse(
+          localStorage.getItem('guestEnrollments') || '[]'
+        ) as string[];
+        if (!stored.includes(course.id)) {
+          stored.push(course.id);
+          localStorage.setItem('guestEnrollments', JSON.stringify(stored));
+        }
+        return;
+      }
+
       const { error } = await supabase
         .from('course_enrollments')
-        .insert([{
-          user_id: user.id,
-          course_id: course.id
-        }]);
-      
+        .insert([
+          {
+            user_id: user.id,
+            course_id: course.id,
+          },
+        ]);
+
       if (error) throw error;
 
       // Update enrollment count
@@ -210,7 +221,7 @@ const CourseCard = ({ course, isEnrolled, viewMode }: CourseCardProps) => {
                 <Button
                   size="sm"
                   onClick={() => enrollMutation.mutate()}
-                  disabled={!user || enrollMutation.isPending}
+                  disabled={enrollMutation.isPending}
                 >
                   {enrollMutation.isPending ? "Enrolling..." : "Enroll Free"}
                 </Button>
@@ -308,7 +319,7 @@ const CourseCard = ({ course, isEnrolled, viewMode }: CourseCardProps) => {
           <Button
             className="w-full"
             onClick={() => enrollMutation.mutate()}
-            disabled={!user || enrollMutation.isPending}
+            disabled={enrollMutation.isPending}
           >
             {enrollMutation.isPending ? "Enrolling..." : "Enroll Free"}
           </Button>

--- a/src/pages/Academy.tsx
+++ b/src/pages/Academy.tsx
@@ -8,14 +8,13 @@ import AcademyHero from "@/components/academy/AcademyHero";
 import CourseGrid from "@/components/academy/CourseGrid";
 import CategoryFilter from "@/components/academy/CategoryFilter";
 import { SearchBar } from "@/components/SearchBar";
-import { useAuth } from "@/context/AuthContext";
+import { useUserEnrollments } from "@/hooks/useAcademy";
 import { useLanguage } from "@/context/LanguageContext";
 
 const Academy = () => {
   const [selectedCategory, setSelectedCategory] = useState<string>("all");
   const [searchQuery, setSearchQuery] = useState("");
   const [difficulty, setDifficulty] = useState<string>("all");
-  const { user } = useAuth();
   const { t } = useLanguage();
 
   const { data: categories } = useQuery({
@@ -65,21 +64,7 @@ const Academy = () => {
     }
   });
 
-  const { data: userEnrollments } = useQuery({
-    queryKey: ['user-enrollments', user?.id],
-    queryFn: async () => {
-      if (!user) return [];
-      
-      const { data, error } = await supabase
-        .from('course_enrollments')
-        .select('course_id')
-        .eq('user_id', user.id);
-      
-      if (error) throw error;
-      return data.map(e => e.course_id);
-    },
-    enabled: !!user
-  });
+  const { data: userEnrollments } = useUserEnrollments();
 
   return (
     <ThemeProvider>


### PR DESCRIPTION
## Summary
- allow anonymous enrollments and progress tracking in `useAcademy`
- remove login requirement from course card enroll button
- load guest enrollments in Academy page

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68859457093c832e9b72dd891447e00a