### PR TITLE
Allow guest job posts

### DIFF
--- a/src/hooks/useJobPosts.ts
+++ b/src/hooks/useJobPosts.ts
@@ -85,7 +85,9 @@ export const useCreateJobPost = () => {
       job_type: 'full-time' | 'part-time' | 'contract' | 'freelance';
       salary_type: 'hourly' | 'fixed' | 'monthly';
       salary_min: number;
-      employer_id: string;
+      employer_id?: string;
+      contact_name?: string;
+      contact_email?: string;
       benefits?: string[];
       requirements?: string[];
       salary_max?: number;
@@ -95,12 +97,14 @@ export const useCreateJobPost = () => {
       longitude?: number;
     }) => {
       // Validate required fields
-      if (!jobData.employer_id) {
-        throw new Error('Employer ID is required');
-      }
-
       if (!jobData.title || !jobData.description) {
         throw new Error('Title and description are required');
+      }
+
+      if (!jobData.employer_id) {
+        if (!jobData.contact_name || !jobData.contact_email) {
+          throw new Error('Contact name and email are required for guest posts');
+        }
       }
 
       // Set the job status to pending for moderation

--- a/src/integrations/supabase/types.ts
+++ b/src/integrations/supabase/types.ts
@@ -1407,7 +1407,9 @@ export type Database = {
           category: string
           created_at: string | null
           description: string
-          employer_id: string
+          employer_id: string | null
+          contact_name: string | null
+          contact_email: string | null
           expires_at: string | null
           id: string
           job_type: Database["public"]["Enums"]["job_type"]
@@ -1428,7 +1430,9 @@ export type Database = {
           category: string
           created_at?: string | null
           description: string
-          employer_id: string
+          employer_id?: string | null
+          contact_name?: string | null
+          contact_email?: string | null
           expires_at?: string | null
           id?: string
           job_type: Database["public"]["Enums"]["job_type"]
@@ -1449,7 +1453,9 @@ export type Database = {
           category?: string
           created_at?: string | null
           description?: string
-          employer_id?: string
+          employer_id?: string | null
+          contact_name?: string | null
+          contact_email?: string | null
           expires_at?: string | null
           id?: string
           job_type?: Database["public"]["Enums"]["job_type"]

--- a/src/pages/PostJob.tsx
+++ b/src/pages/PostJob.tsx
@@ -33,6 +33,8 @@ const PostJob = () => {
     benefits: [] as string[],
     urgency: "medium" as "low" | "medium" | "high",
     expires_at: "",
+    contact_name: "",
+    contact_email: "",
   });
 
   const [requirementInput, setRequirementInput] = useState("");
@@ -79,16 +81,6 @@ const PostJob = () => {
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
     
-    if (!user?.id) {
-      toast({
-        title: "Authentication Required",
-        description: "Please sign in to post a job.",
-        variant: "destructive"
-      });
-      navigate("/auth");
-      return;
-    }
-    
     if (!formData.title || !formData.description || !formData.category || !formData.location) {
       toast({
         title: "Missing Information",
@@ -112,7 +104,9 @@ const PostJob = () => {
         benefits: formData.benefits,
         urgency: formData.urgency,
         expires_at: formData.expires_at || undefined,
-        employer_id: user.id
+        employer_id: user?.id,
+        contact_name: formData.contact_name || undefined,
+        contact_email: formData.contact_email || undefined
       });
 
       toast({
@@ -146,30 +140,7 @@ const PostJob = () => {
     );
   }
 
-  if (!user) {
-    return (
-      <div className="min-h-screen bg-background">
-        <Navbar />
-        <div className="container mx-auto px-4 py-8">
-          <Card className="max-w-md mx-auto">
-            <CardContent className="pt-6">
-              <div className="text-center">
-                <AlertCircle className="h-12 w-12 text-muted-foreground mx-auto mb-4" />
-                <h2 className="text-xl font-semibold mb-2">Sign In Required</h2>
-                <p className="text-muted-foreground mb-4">
-                  You need to be signed in to post a job.
-                </p>
-                <Button asChild>
-                  <a href="/auth">Sign In / Register</a>
-                </Button>
-              </div>
-            </CardContent>
-          </Card>
-        </div>
-        <Footer />
-      </div>
-    );
-  }
+
 
   return (
     <div className="min-h-screen bg-background">
@@ -193,6 +164,29 @@ const PostJob = () => {
             </CardHeader>
             <CardContent>
               <form onSubmit={handleSubmit} className="space-y-6">
+                {!user && (
+                  <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
+                    <div>
+                      <Label htmlFor="contact_name">Your Name *</Label>
+                      <Input
+                        id="contact_name"
+                        value={formData.contact_name}
+                        onChange={(e) => handleInputChange("contact_name", e.target.value)}
+                        required
+                      />
+                    </div>
+                    <div>
+                      <Label htmlFor="contact_email">Email *</Label>
+                      <Input
+                        id="contact_email"
+                        type="email"
+                        value={formData.contact_email}
+                        onChange={(e) => handleInputChange("contact_email", e.target.value)}
+                        required
+                      />
+                    </div>
+                  </div>
+                )}
                 <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
                   <div>
                     <Label htmlFor="title">Job Title *</Label>

--- a/src/pages/admin/AdminJobs.tsx
+++ b/src/pages/admin/AdminJobs.tsx
@@ -12,9 +12,10 @@ import {
   Clock, 
   Eye, 
   MapPin, 
-  DollarSign, 
+  DollarSign,
   Users,
-  Loader2
+  Loader2,
+  Mail
 } from "lucide-react";
 import { JobPost } from "@/types/marketplace";
 import { Profile } from "@/types/profile";
@@ -90,8 +91,14 @@ const AdminJobs = () => {
             <div className="flex items-center gap-4 text-sm text-muted-foreground">
               <span className="flex items-center">
                 <Users className="h-4 w-4 mr-1" />
-                {job.employer?.full_name || 'Unknown Employer'}
+                {job.employer?.full_name || job.contact_name || 'Unknown Employer'}
               </span>
+              {!job.employer_id && job.contact_email && (
+                <span className="flex items-center">
+                  <Mail className="h-4 w-4 mr-1" />
+                  {job.contact_email}
+                </span>
+              )}
               <span className="flex items-center">
                 <MapPin className="h-4 w-4 mr-1" />
                 {job.location}

--- a/src/types/marketplace.ts
+++ b/src/types/marketplace.ts
@@ -15,7 +15,9 @@ export interface User {
 
 export interface JobPost {
   id: string;
-  employer_id: string;
+  employer_id?: string;
+  contact_name?: string | null;
+  contact_email?: string | null;
   title: string;
   description: string;
   category: string;

--- a/supabase/migrations/20250728000000-ffc48de0-9f7e-45e7-abe8-808fc3b36df1.sql
+++ b/supabase/migrations/20250728000000-ffc48de0-9f7e-45e7-abe8-808fc3b36df1.sql
@@ -1,0 +1,6 @@
+-- Allow guest job posts
+ALTER TABLE job_posts ALTER COLUMN employer_id DROP NOT NULL;
+
+ALTER TABLE job_posts
+  ADD COLUMN contact_name TEXT,
+  ADD COLUMN contact_email TEXT;


### PR DESCRIPTION
## Summary
- enable guests to post jobs by removing sign-in requirement
- capture contact name & email when a job is submitted by a guest
- make employer_id optional for job posts
- update generated supabase types
- display guest contact info in admin job list
- create migration to store guest contact details

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_688594519458832eaecef07fd87a439b