### PR TITLE
Refactor GPTAssistant to use Supabase

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ Welcome to the Zwanski Tech platform! This project powers [zwanski.org](https://
 - 🧑‍💻 Community: forums, live chat, Telegram integration
 - 📱 Free IMEI checker & device tools
 - 🖥️ Interactive 3D computer model (React Three Fiber)
+- 🤖 AI utilities powered by Supabase edge functions
 - 🌙 Dark & light mode, responsive design
 - 🔒 GDPR-ready, privacy-focused
 

--- a/src/components/GPTAssistant.tsx
+++ b/src/components/GPTAssistant.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useState } from "react";
+import { supabase } from "@/integrations/supabase/client";
 import ReactMarkdown from "react-markdown";
 import {
   Card,
@@ -37,12 +38,10 @@ export default function GPTAssistant() {
     setLoading(true);
     setResult("");
     try {
-      const res = await fetch("https://api.zwanski.org/api/ai-tools", {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ tool, prompt: input }),
+      const { data, error } = await supabase.functions.invoke("chatgpt-tools", {
+        body: { tool, prompt: input },
       });
-      const data = await res.json();
+      if (error) throw error;
       setResult(data.result || "No response received.");
     } catch (err) {
       setResult(


### PR DESCRIPTION
## Summary
- update GPTAssistant component to call Supabase edge function instead of remote API
- note AI utilities in README

## Testing
- `npm run test`
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68859d16db08832ebce4278f4768c773