### PR TITLE
Add PDF export for CV generator

### DIFF
--- a/supabase/functions/generate-pdf/index.ts
+++ b/supabase/functions/generate-pdf/index.ts
@@ -1,0 +1,54 @@
+import { serve } from "https://deno.land/std@0.190.0/http/server.ts";
+import { PDFDocument, StandardFonts } from "npm:pdf-lib@1.17.1";
+
+const corsHeaders = {
+  "Access-Control-Allow-Origin": "*",
+  "Access-Control-Allow-Headers": "authorization, x-client-info, apikey, content-type",
+};
+
+serve(async (req) => {
+  if (req.method === "OPTIONS") {
+    return new Response(null, { headers: corsHeaders });
+  }
+
+  try {
+    const { text } = await req.json();
+    if (!text) {
+      return new Response(
+        JSON.stringify({ error: "Text is required" }),
+        { status: 400, headers: { ...corsHeaders, "Content-Type": "application/json" } }
+      );
+    }
+
+    const pdfDoc = await PDFDocument.create();
+    let page = pdfDoc.addPage();
+    const { width, height } = page.getSize();
+    const font = await pdfDoc.embedFont(StandardFonts.Helvetica);
+    const fontSize = 12;
+    const margin = 50;
+    let y = height - margin;
+
+    for (const line of String(text).split(/\r?\n/)) {
+      page.drawText(line, { x: margin, y, size: fontSize, font });
+      y -= fontSize + 4;
+      if (y < margin) {
+        page = pdfDoc.addPage();
+        y = height - margin;
+      }
+    }
+
+    const pdfBytes = await pdfDoc.save();
+    const base64 = btoa(String.fromCharCode(...new Uint8Array(pdfBytes)));
+
+    return new Response(
+      JSON.stringify({ pdf: base64 }),
+      { headers: { ...corsHeaders, "Content-Type": "application/json" } }
+    );
+  } catch (err) {
+    console.error("generate-pdf error", err);
+    return new Response(
+      JSON.stringify({ error: "Internal server error" }),
+      { status: 500, headers: { ...corsHeaders, "Content-Type": "application/json" } }
+    );
+  }
+});


### PR DESCRIPTION
## Summary
- generate PDFs on the server with new `generate-pdf` edge function
- auto-create a downloadable CV PDF in `CVGenerator`

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68859d169b7c832e9c80610e96008b24