### PR TITLE
Add new AI utilities

### DIFF
--- a/src/components/GameGenerator.tsx
+++ b/src/components/GameGenerator.tsx
@@ -1,0 +1,62 @@
+import { useState } from "react";
+import { supabase } from "@/integrations/supabase/client";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Button } from "@/components/ui/button";
+import { Textarea } from "@/components/ui/textarea";
+import { Loader2 } from "lucide-react";
+
+export default function GameGenerator() {
+  const [prompt, setPrompt] = useState("");
+  const [result, setResult] = useState("");
+  const [loading, setLoading] = useState(false);
+
+  async function handleSubmit(e: React.FormEvent) {
+    e.preventDefault();
+    setLoading(true);
+    setResult("");
+    try {
+      const { data, error } = await supabase.functions.invoke("chatgpt-tools", {
+        body: { tool: "game", prompt },
+      });
+      if (error) throw error;
+      setResult(data.result || "No response received.");
+    } catch (err) {
+      setResult("Failed to generate a game. Please try again.");
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  return (
+    <Card className="w-full">
+      <CardHeader>
+        <CardTitle>Mini-Game Generator</CardTitle>
+      </CardHeader>
+      <CardContent className="space-y-4">
+        <form onSubmit={handleSubmit} className="space-y-3">
+          <div>
+            <label htmlFor="game-prompt" className="block mb-1 text-sm font-medium">
+              Game Idea
+            </label>
+            <Textarea
+              id="game-prompt"
+              value={prompt}
+              onChange={(e) => setPrompt(e.target.value)}
+              placeholder="Describe the type of game"
+              rows={4}
+            />
+          </div>
+          <Button type="submit" disabled={loading} className="flex items-center">
+            {loading && <Loader2 className="mr-2 h-4 w-4 animate-spin" />}
+            {loading ? "Generating..." : "Generate"}
+          </Button>
+        </form>
+        {result && (
+          <div className="prose max-w-none bg-muted/50 p-4 rounded" aria-live="polite">
+            {result}
+          </div>
+        )}
+      </CardContent>
+    </Card>
+  );
+}

--- a/src/components/LanguageHelper.tsx
+++ b/src/components/LanguageHelper.tsx
@@ -1,0 +1,62 @@
+import { useState } from "react";
+import { supabase } from "@/integrations/supabase/client";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Button } from "@/components/ui/button";
+import { Textarea } from "@/components/ui/textarea";
+import { Loader2 } from "lucide-react";
+
+export default function LanguageHelper() {
+  const [prompt, setPrompt] = useState("");
+  const [result, setResult] = useState("");
+  const [loading, setLoading] = useState(false);
+
+  async function handleSubmit(e: React.FormEvent) {
+    e.preventDefault();
+    setLoading(true);
+    setResult("");
+    try {
+      const { data, error } = await supabase.functions.invoke("chatgpt-tools", {
+        body: { tool: "language", prompt },
+      });
+      if (error) throw error;
+      setResult(data.result || "No response received.");
+    } catch (err) {
+      setResult("Failed to get language help. Please try again.");
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  return (
+    <Card className="w-full">
+      <CardHeader>
+        <CardTitle>Language Learning Helper</CardTitle>
+      </CardHeader>
+      <CardContent className="space-y-4">
+        <form onSubmit={handleSubmit} className="space-y-3">
+          <div>
+            <label htmlFor="language-prompt" className="block mb-1 text-sm font-medium">
+              What would you like to learn?
+            </label>
+            <Textarea
+              id="language-prompt"
+              value={prompt}
+              onChange={(e) => setPrompt(e.target.value)}
+              placeholder="Ask about grammar, vocabulary, etc."
+              rows={4}
+            />
+          </div>
+          <Button type="submit" disabled={loading} className="flex items-center">
+            {loading && <Loader2 className="mr-2 h-4 w-4 animate-spin" />}
+            {loading ? "Generating..." : "Generate"}
+          </Button>
+        </form>
+        {result && (
+          <div className="prose max-w-none bg-muted/50 p-4 rounded" aria-live="polite">
+            {result}
+          </div>
+        )}
+      </CardContent>
+    </Card>
+  );
+}

--- a/src/components/StudentAssistant.tsx
+++ b/src/components/StudentAssistant.tsx
@@ -1,0 +1,62 @@
+import { useState } from "react";
+import { supabase } from "@/integrations/supabase/client";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Button } from "@/components/ui/button";
+import { Textarea } from "@/components/ui/textarea";
+import { Loader2 } from "lucide-react";
+
+export default function StudentAssistant() {
+  const [prompt, setPrompt] = useState("");
+  const [result, setResult] = useState("");
+  const [loading, setLoading] = useState(false);
+
+  async function handleSubmit(e: React.FormEvent) {
+    e.preventDefault();
+    setLoading(true);
+    setResult("");
+    try {
+      const { data, error } = await supabase.functions.invoke("chatgpt-tools", {
+        body: { tool: "student", prompt },
+      });
+      if (error) throw error;
+      setResult(data.result || "No response received.");
+    } catch (err) {
+      setResult("Failed to get assistance. Please try again.");
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  return (
+    <Card className="w-full">
+      <CardHeader>
+        <CardTitle>Student Assistant</CardTitle>
+      </CardHeader>
+      <CardContent className="space-y-4">
+        <form onSubmit={handleSubmit} className="space-y-3">
+          <div>
+            <label htmlFor="student-prompt" className="block mb-1 text-sm font-medium">
+              Question or Topic
+            </label>
+            <Textarea
+              id="student-prompt"
+              value={prompt}
+              onChange={(e) => setPrompt(e.target.value)}
+              placeholder="Enter your study question"
+              rows={4}
+            />
+          </div>
+          <Button type="submit" disabled={loading} className="flex items-center">
+            {loading && <Loader2 className="mr-2 h-4 w-4 animate-spin" />}
+            {loading ? "Generating..." : "Generate"}
+          </Button>
+        </form>
+        {result && (
+          <div className="prose max-w-none bg-muted/50 p-4 rounded" aria-live="polite">
+            {result}
+          </div>
+        )}
+      </CardContent>
+    </Card>
+  );
+}

--- a/src/components/VideoFinder.tsx
+++ b/src/components/VideoFinder.tsx
@@ -1,0 +1,62 @@
+import { useState } from "react";
+import { supabase } from "@/integrations/supabase/client";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Button } from "@/components/ui/button";
+import { Textarea } from "@/components/ui/textarea";
+import { Loader2 } from "lucide-react";
+
+export default function VideoFinder() {
+  const [topic, setTopic] = useState("");
+  const [result, setResult] = useState("");
+  const [loading, setLoading] = useState(false);
+
+  async function handleSubmit(e: React.FormEvent) {
+    e.preventDefault();
+    setLoading(true);
+    setResult("");
+    try {
+      const { data, error } = await supabase.functions.invoke("chatgpt-tools", {
+        body: { tool: "video", prompt: topic },
+      });
+      if (error) throw error;
+      setResult(data.result || "No response received.");
+    } catch (err) {
+      setResult("Failed to find videos. Please try again.");
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  return (
+    <Card className="w-full">
+      <CardHeader>
+        <CardTitle>Educational Video Finder</CardTitle>
+      </CardHeader>
+      <CardContent className="space-y-4">
+        <form onSubmit={handleSubmit} className="space-y-3">
+          <div>
+            <label htmlFor="video-topic" className="block mb-1 text-sm font-medium">
+              Topic
+            </label>
+            <Textarea
+              id="video-topic"
+              value={topic}
+              onChange={(e) => setTopic(e.target.value)}
+              placeholder="Enter a topic to search videos"
+              rows={3}
+            />
+          </div>
+          <Button type="submit" disabled={loading} className="flex items-center">
+            {loading && <Loader2 className="mr-2 h-4 w-4 animate-spin" />}
+            {loading ? "Searching..." : "Search"}
+          </Button>
+        </form>
+        {result && (
+          <div className="prose max-w-none bg-muted/50 p-4 rounded" aria-live="polite">
+            {result}
+          </div>
+        )}
+      </CardContent>
+    </Card>
+  );
+}

--- a/src/components/VulnerabilityScanner.tsx
+++ b/src/components/VulnerabilityScanner.tsx
@@ -1,0 +1,62 @@
+import { useState } from "react";
+import { supabase } from "@/integrations/supabase/client";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Button } from "@/components/ui/button";
+import { Textarea } from "@/components/ui/textarea";
+import { Loader2 } from "lucide-react";
+
+export default function VulnerabilityScanner() {
+  const [input, setInput] = useState("");
+  const [result, setResult] = useState("");
+  const [loading, setLoading] = useState(false);
+
+  async function handleSubmit(e: React.FormEvent) {
+    e.preventDefault();
+    setLoading(true);
+    setResult("");
+    try {
+      const { data, error } = await supabase.functions.invoke("chatgpt-tools", {
+        body: { tool: "vuln", prompt: input },
+      });
+      if (error) throw error;
+      setResult(data.result || "No response received.");
+    } catch (err) {
+      setResult("Failed to scan for vulnerabilities. Please try again.");
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  return (
+    <Card className="w-full">
+      <CardHeader>
+        <CardTitle>Vulnerability Scanner</CardTitle>
+      </CardHeader>
+      <CardContent className="space-y-4">
+        <form onSubmit={handleSubmit} className="space-y-3">
+          <div>
+            <label htmlFor="vuln-input" className="block mb-1 text-sm font-medium">
+              URL or Code Snippet
+            </label>
+            <Textarea
+              id="vuln-input"
+              value={input}
+              onChange={(e) => setInput(e.target.value)}
+              placeholder="Paste code or enter a URL"
+              rows={4}
+            />
+          </div>
+          <Button type="submit" disabled={loading} className="flex items-center">
+            {loading && <Loader2 className="mr-2 h-4 w-4 animate-spin" />}
+            {loading ? "Scanning..." : "Scan"}
+          </Button>
+        </form>
+        {result && (
+          <div className="prose max-w-none bg-muted/50 p-4 rounded" aria-live="polite">
+            {result}
+          </div>
+        )}
+      </CardContent>
+    </Card>
+  );
+}

--- a/src/pages/ai.tsx
+++ b/src/pages/ai.tsx
@@ -9,6 +9,11 @@ import CVGenerator from "@/components/CVGenerator";
 import NewsGenerator from "@/components/NewsGenerator";
 import SEOScanner from "@/components/SEOScanner";
 import MentalHealthBot from "@/components/MentalHealthBot";
+import GameGenerator from "@/components/GameGenerator";
+import StudentAssistant from "@/components/StudentAssistant";
+import VulnerabilityScanner from "@/components/VulnerabilityScanner";
+import LanguageHelper from "@/components/LanguageHelper";
+import VideoFinder from "@/components/VideoFinder";
 
 export default function AIDashboardPage() {
   const navigate = useNavigate();
@@ -30,11 +35,16 @@ export default function AIDashboardPage() {
           <ArrowLeft className="h-4 w-4" /> Home
         </Button>
         <Tabs defaultValue="cv" className="w-full">
-          <TabsList className="grid w-full grid-cols-4">
+          <TabsList className="grid w-full grid-cols-4 md:grid-cols-5">
             <TabsTrigger value="cv">CV Generator</TabsTrigger>
             <TabsTrigger value="news">News</TabsTrigger>
             <TabsTrigger value="seo">SEO Scanner</TabsTrigger>
             <TabsTrigger value="mental">Mental Health</TabsTrigger>
+            <TabsTrigger value="game">Mini-Game</TabsTrigger>
+            <TabsTrigger value="student">Student Assistant</TabsTrigger>
+            <TabsTrigger value="vuln">Vulnerability Scan</TabsTrigger>
+            <TabsTrigger value="language">Language Helper</TabsTrigger>
+            <TabsTrigger value="video">Video Finder</TabsTrigger>
           </TabsList>
           <TabsContent value="cv" className="mt-6">
             <CVGenerator />
@@ -47,6 +57,21 @@ export default function AIDashboardPage() {
           </TabsContent>
           <TabsContent value="mental" className="mt-6">
             <MentalHealthBot />
+          </TabsContent>
+          <TabsContent value="game" className="mt-6">
+            <GameGenerator />
+          </TabsContent>
+          <TabsContent value="student" className="mt-6">
+            <StudentAssistant />
+          </TabsContent>
+          <TabsContent value="vuln" className="mt-6">
+            <VulnerabilityScanner />
+          </TabsContent>
+          <TabsContent value="language" className="mt-6">
+            <LanguageHelper />
+          </TabsContent>
+          <TabsContent value="video" className="mt-6">
+            <VideoFinder />
           </TabsContent>
         </Tabs>
       </main>

--- a/supabase/functions/chatgpt-tools/index.ts
+++ b/supabase/functions/chatgpt-tools/index.ts
@@ -38,6 +38,31 @@ serve(async (req) => {
       messages.unshift({ role: "system", content: "Act as an SEO expert and analyse the provided text." });
     } else if (tool === "mental") {
       messages.unshift({ role: "system", content: "Provide supportive mental health advice." });
+    } else if (tool === "game") {
+      messages.unshift({
+        role: "system",
+        content: "Generate a short concept or instructions for a simple text-based mini-game based on the user's idea.",
+      });
+    } else if (tool === "student") {
+      messages.unshift({
+        role: "system",
+        content: "Act as a helpful tutor and answer the student's question in a clear and concise manner.",
+      });
+    } else if (tool === "vuln") {
+      messages.unshift({
+        role: "system",
+        content: "Identify potential security vulnerabilities in the provided text and suggest improvements.",
+      });
+    } else if (tool === "language") {
+      messages.unshift({
+        role: "system",
+        content: "Assist with language learning queries, providing grammar explanations and examples.",
+      });
+    } else if (tool === "video") {
+      messages.unshift({
+        role: "system",
+        content: "Suggest educational video topics or titles related to the user's query.",
+      });
     }
 
     const response = await fetch("https://api.openai.com/v1/chat/completions", {


### PR DESCRIPTION
## Summary
- create mini-game generator, student assistant, vulnerability scanner, language helper and educational video finder components
- register them in the AI dashboard page
- extend Supabase `chatgpt-tools` function to handle new tools

## Testing
- `npm run lint`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68859d162e20832e94a7fc6b2e6d47c1