### PR TITLE
Add more tools to ChatGPT helper

### DIFF
--- a/src/components/GPTAssistant.tsx
+++ b/src/components/GPTAssistant.tsx
@@ -18,12 +18,16 @@ import {
 } from "@/components/ui/select";
 import { Textarea } from "@/components/ui/textarea";
 import { Loader2 } from "lucide-react";
+import { supabase } from "@/integrations/supabase/client";
 
 const TOOLS = [
   { id: "chatbot", label: "General Chatbot" },
   { id: "resume", label: "Resume Enhancer" },
   { id: "blog", label: "Blog Intro Generator" },
   { id: "code", label: "Code Explainer" },
+  { id: "student", label: "Student Tutor" },
+  { id: "game", label: "Text Adventure" },
+  { id: "bugfix", label: "Bug Fix Assistant" },
 ];
 
 export default function GPTAssistant() {
@@ -37,12 +41,10 @@ export default function GPTAssistant() {
     setLoading(true);
     setResult("");
     try {
-      const res = await fetch("https://api.zwanski.org/api/ai-tools", {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ tool, prompt: input }),
+      const { data, error } = await supabase.functions.invoke("chatgpt-tools", {
+        body: { tool, prompt: input },
       });
-      const data = await res.json();
+      if (error) throw error;
       setResult(data.result || "No response received.");
     } catch (err) {
       setResult(

--- a/supabase/functions/chatgpt-tools/index.ts
+++ b/supabase/functions/chatgpt-tools/index.ts
@@ -33,11 +33,43 @@ serve(async (req) => {
     ];
 
     if (tool === "cv") {
-      messages.unshift({ role: "system", content: "Generate a concise professional CV based on the user input." });
+      messages.unshift({
+        role: "system",
+        content: "Generate a concise professional CV based on the user input.",
+      });
     } else if (tool === "seo") {
-      messages.unshift({ role: "system", content: "Act as an SEO expert and analyse the provided text." });
+      messages.unshift({
+        role: "system",
+        content: "Act as an SEO expert and analyse the provided text.",
+      });
     } else if (tool === "mental") {
-      messages.unshift({ role: "system", content: "Provide supportive mental health advice." });
+      messages.unshift({
+        role: "system",
+        content: "Provide supportive mental health advice.",
+      });
+    } else if (tool === "student") {
+      messages.unshift({
+        role: "system",
+        content:
+          "You are a patient instructor. Offer step-by-step explanations for the user's question.",
+      });
+    } else if (tool === "code") {
+      messages.unshift({
+        role: "system",
+        content: "Explain what the following code does in simple terms.",
+      });
+    } else if (tool === "game") {
+      messages.unshift({
+        role: "system",
+        content:
+          "You are a text adventure game master. Continue the story based on user input.",
+      });
+    } else if (tool === "bugfix") {
+      messages.unshift({
+        role: "system",
+        content:
+          "Provide a concise vulnerability assessment and suggest fixes for the given code or description.",
+      });
     }
 
     const response = await fetch("https://api.openai.com/v1/chat/completions", {


### PR DESCRIPTION
## Summary
- extend chatgpt-tools function with new system prompts for `student`, `code`, `game` and `bugfix`
- support the new tools in `GPTAssistant` and switch to using the Supabase function

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68859d14691c832eab49ff4dd2b0fc81