### PR TITLE
Add detailed dev errors in chatgpt function

### DIFF
--- a/supabase/functions/chatgpt-tools/index.test.ts
+++ b/supabase/functions/chatgpt-tools/index.test.ts
@@ -46,4 +46,42 @@ describe('chatgpt-tools', () => {
     const json = await res.json();
     expect(json.result).toBe('ok');
   });
+
+  it('exposes error message in development', async () => {
+    process.env.OPENAI_API_KEY = 'x';
+    const prev = process.env.NODE_ENV;
+    process.env.NODE_ENV = 'development';
+    const fetchMock = vi.fn(async () => new Response('err', { status: 500 }));
+    (globalThis as any).fetch = fetchMock;
+
+    const req = new Request('http://localhost', {
+      method: 'POST',
+      body: JSON.stringify({ prompt: 'hello', tool: 'cv' }),
+      headers: { 'Content-Type': 'application/json' },
+    });
+    const res = await handler(req);
+    expect(res.status).toBe(500);
+    const json = await res.json();
+    expect(json.error).toContain('OpenAI API error: 500');
+    process.env.NODE_ENV = prev;
+  });
+
+  it('hides error message in production', async () => {
+    process.env.OPENAI_API_KEY = 'x';
+    const prev = process.env.NODE_ENV;
+    process.env.NODE_ENV = 'production';
+    const fetchMock = vi.fn(async () => new Response('err', { status: 500 }));
+    (globalThis as any).fetch = fetchMock;
+
+    const req = new Request('http://localhost', {
+      method: 'POST',
+      body: JSON.stringify({ prompt: 'hello', tool: 'cv' }),
+      headers: { 'Content-Type': 'application/json' },
+    });
+    const res = await handler(req);
+    expect(res.status).toBe(500);
+    const json = await res.json();
+    expect(json.error).toBe('Internal server error');
+    process.env.NODE_ENV = prev;
+  });
 });

--- a/supabase/functions/chatgpt-tools/index.ts
+++ b/supabase/functions/chatgpt-tools/index.ts
@@ -121,8 +121,10 @@ serve(async (req) => {
     );
   } catch (err) {
     console.error("chatgpt-tools error", err);
+    const isDevelopment = Deno.env.get("NODE_ENV") === "development";
+    const message = isDevelopment && err instanceof Error ? err.message : "Internal server error";
     return new Response(
-      JSON.stringify({ error: "Internal server error" }),
+      JSON.stringify({ error: message }),
       { status: 500, headers: { ...corsHeaders, "Content-Type": "application/json" } }
     );
   }


### PR DESCRIPTION
## Summary
- include NODE_ENV check in chatgpt-tools function
- return detailed error messages in development
- test that dev exposes details while production hides them

## Testing
- `npm run lint`
- `npx vitest run`

------
https://chatgpt.com/codex/tasks/task_e_6885ab024810832e9c4e22318dd9da33