### PR TITLE
Fix root element handling in React entrypoint

### DIFF
--- a/src/main.tsx
+++ b/src/main.tsx
@@ -4,4 +4,11 @@ import './index.css'
 import './styles/performance.css'
 import './styles/homepage-stability.css'
 
-createRoot(document.getElementById("root")!).render(<App />);
+const rootEl = document.getElementById('root')
+
+if (!rootEl) {
+  console.error('Root element not found')
+} else {
+  console.log('Mounting React app')
+  createRoot(rootEl).render(<App />)
+}


### PR DESCRIPTION
## Summary
- add a check for the root element before mounting the app

## Testing
- `npm run lint`
- `npm test` *(fails: Cannot read properties of undefined (reading '1'))*

------
https://chatgpt.com/codex/tasks/task_e_6885aaee4f3c832eaff9959ea6a9abeb