### PR TITLE
Add dev-only render logs

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -96,6 +96,9 @@ import "./styles/animations.css";
 const queryClient = new QueryClient(); // Force refresh for Tools import
 
 function App() {
+  if (process.env.NODE_ENV === 'development') {
+    console.log('App component rendering');
+  }
   // Performance monitoring hooks - moved to top level to follow React Rules of Hooks
   usePerformanceMonitoring();
   useMemoryMonitoring();

--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -139,7 +139,10 @@ const Index = () => {
   ];
 
   // Render with error boundary and fallback
-  const renderPageContent = () => {
+const renderPageContent = () => {
+    if (process.env.NODE_ENV === 'development') {
+      console.log('renderPageContent called');
+    }
     try {
       return (
         <>
@@ -421,7 +424,7 @@ const Index = () => {
       );
     } catch (error) {
       if (process.env.NODE_ENV === 'development') {
-        console.error('Homepage rendering error:', error);
+        console.error('renderPageContent error:', error);
       }
       return (
         <div className="min-h-screen flex items-center justify-center bg-background">


### PR DESCRIPTION
## Summary
- log when the App component renders
- log renderPageContent start and failures in `Index`

## Testing
- `npx vitest run`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6885aafaafe4832e96134def87965803