### PR TITLE
Fix dev error output in chatgpt function

### DIFF
--- a/supabase/functions/chatgpt-tools/index.ts
+++ b/supabase/functions/chatgpt-tools/index.ts
@@ -122,9 +122,12 @@ serve(async (req) => {
   } catch (err) {
     console.error("chatgpt-tools error", err);
     const isDevelopment = Deno.env.get("NODE_ENV") === "development";
-    const message = isDevelopment && err instanceof Error ? err.message : "Internal server error";
+    const errorPayload =
+      isDevelopment && err instanceof Error
+        ? { error: err.message }
+        : { error: "Internal server error" };
     return new Response(
-      JSON.stringify({ error: message }),
+      JSON.stringify(errorPayload),
       { status: 500, headers: { ...corsHeaders, "Content-Type": "application/json" } }
     );
   }


### PR DESCRIPTION
## Summary
- show detailed error messages from ChatGPT tools when `NODE_ENV` is `development`
- otherwise return a generic message

## Testing
- `npm run lint`
- `npx vitest run`

------
https://chatgpt.com/codex/tasks/task_e_6885af2d1d40832ea969233ce1039d0a