### PR TITLE
Configure security headers in htaccess

### DIFF
--- a/index.html
+++ b/index.html
@@ -27,12 +27,7 @@
 
     <link rel="apple-touch-icon" href="/favicon-professional.svg">
     
-    <!-- Security Headers -->
-    <meta http-equiv="Strict-Transport-Security" content="max-age=31536000; includeSubDomains; preload">
-    <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' 'unsafe-inline' https://www.googletagmanager.com https://static.axept.io https://cdn.gpteng.co https://js.hcaptcha.com; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; font-src 'self' https://fonts.gstatic.com; img-src 'self' data: https:; connect-src 'self' https: wss: https://hcaptcha.com; frame-src 'self' https: https://hcaptcha.com;">
-    <meta http-equiv="X-Content-Type-Options" content="nosniff">
-    <meta http-equiv="X-Frame-Options" content="DENY">
-    <meta http-equiv="X-XSS-Protection" content="1; mode=block">
+    <!-- Security headers set via server configuration -->
     <meta http-equiv="Referrer-Policy" content="strict-origin-when-cross-origin">
     <link rel="alternate" type="application/atom+xml" title="Zwanski Tech Website Feed" href="https://zwanski2019.github.io/ZWANSKI-TECH/atom.xml" />
     <!-- Optimized critical font preload -->

--- a/public/.htaccess
+++ b/public/.htaccess
@@ -44,6 +44,7 @@
     
     # Security Headers
     Header always set Strict-Transport-Security "max-age=31536000; includeSubDomains; preload"
+    Header always set Content-Security-Policy "default-src 'self'; script-src 'self' https://www.googletagmanager.com https://static.axept.io https://cdn.gpteng.co https://js.hcaptcha.com; style-src 'self' https://fonts.googleapis.com; font-src 'self' https://fonts.gstatic.com; img-src 'self' data: https:; connect-src 'self' https: wss: https://hcaptcha.com; frame-src 'self' https://hcaptcha.com"
     Header always set X-Content-Type-Options "nosniff"
     Header always set X-Frame-Options "DENY"
     Header always set X-XSS-Protection "1; mode=block"


### PR DESCRIPTION
## Summary
- set security headers via `.htaccess`
- remove redundant meta security tags from `index.html`

## Testing
- `npm run lint`
- `npm test` *(fails: chatgpt-tools tests)*

------
https://chatgpt.com/codex/tasks/task_e_6885c0de7cd4832e94cf4eb509c9a21a