### PR TITLE
Fix build failure from Node import in sanitize util

### DIFF
--- a/src/utils/sanitize.ts
+++ b/src/utils/sanitize.ts
@@ -1,11 +1,17 @@
 import createDOMPurify from 'dompurify';
-import { createRequire } from 'module';
 
-// Initialize DOMPurify with either the browser window or jsdom for tests.
-const require = createRequire(import.meta.url);
-const windowRef: Window = typeof window === 'undefined'
-  ? new (require('jsdom').JSDOM)('').window as unknown as Window
-  : window;
+// Initialize DOMPurify with the available Window implementation.
+// When running in Node (tests), fall back to jsdom. This avoids using
+// Node's `module` API which breaks browser builds.
+let windowRef: Window;
+
+if (typeof window === 'undefined') {
+  // eslint-disable-next-line @typescript-eslint/no-var-requires
+  const { JSDOM } = require('jsdom');
+  windowRef = new JSDOM('').window as unknown as Window;
+} else {
+  windowRef = window;
+}
 
 const DOMPurify = createDOMPurify(windowRef);
 


### PR DESCRIPTION
## Summary
- use `jsdom` only when not running in browser

## Testing
- `npm run lint`
- `npm run test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6886c1dcda54832e8c0b6c7dfe05b45e