### PR TITLE
Fix sanitize util jsdom import

### DIFF
--- a/src/utils/sanitize.ts
+++ b/src/utils/sanitize.ts
@@ -7,7 +7,7 @@ let windowRef: Window;
 
 if (typeof window === 'undefined') {
   // eslint-disable-next-line @typescript-eslint/no-var-requires
-  const { JSDOM } = require('jsdom');
+  const { JSDOM } = eval('require')("jsdom");
   windowRef = new JSDOM('').window as unknown as Window;
 } else {
   windowRef = window;


### PR DESCRIPTION
## Summary
- load jsdom using `eval('require')` to prevent bundlers from including Node modules

## Testing
- `npm run lint`
- `npm test -- -t sanitize`

------
https://chatgpt.com/codex/tasks/task_e_6886c736e398832eb799600da3859b71