### PR TITLE
Update env docs for AI tools

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -12,3 +12,9 @@ RSS_FEED_URL=
 NEWSLETTER_TABLE=newsletter_subscribers
 NEWSLETTER_LOG_TABLE=newsletter_logs
 
+# AI tools
+OPENAI_API_KEY=
+GEMINI_API_KEY=
+# Comma-separated list of allowed origins
+ALLOWED_ORIGINS=http://localhost:3000,https://zwanski.org
+

--- a/README.md
+++ b/README.md
@@ -65,6 +65,21 @@ verify_jwt = false
 
 [functions.get-hcaptcha-config]
 verify_jwt = false
+
+### AI Tools Configuration
+
+The AI utilities rely on OpenAI and Gemini APIs. Set these secrets in your
+Supabase project and optionally in a local `.env` file:
+
+```bash
+OPENAI_API_KEY=your-openai-key
+GEMINI_API_KEY=your-gemini-key
+ALLOWED_ORIGINS=http://localhost:3000,https://zwanski.org
+```
+
+`ALLOWED_ORIGINS` controls which domains may call the edge functions.
+Include `http://localhost:3000` when running the frontend locally to avoid
+CORS errors.
 ```
 
 ## 💻 Development Setup


### PR DESCRIPTION
## Summary
- add OPENAI_API_KEY, GEMINI_API_KEY and ALLOWED_ORIGINS examples
- document AI tools configuration in README

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm test --silent` *(fails: vitest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_6886d455d4c0832e818b5875e5ecc337