### PR TITLE
Add AI tools env vars documentation

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -12,3 +12,8 @@ RSS_FEED_URL=
 NEWSLETTER_TABLE=newsletter_subscribers
 NEWSLETTER_LOG_TABLE=newsletter_logs
 
+# AI tools
+OPENAI_API_KEY=
+GEMINI_API_KEY=
+ALLOWED_ORIGINS=
+

--- a/README.md
+++ b/README.md
@@ -149,6 +149,18 @@ Resend.
 The script keeps a log in the `newsletter_logs` table to avoid sending the same
 post more than once in a week.
 
+## 🤖 AI Tools Configuration
+
+Supabase edge functions like `chatgpt-tools` and `gemini-tools` require a few secrets:
+
+```bash
+OPENAI_API_KEY=your-openai-key
+GEMINI_API_KEY=your-gemini-key
+ALLOWED_ORIGINS=http://localhost:3000,https://yourdomain.com
+```
+
+Add these variables in the **Project Settings → Environment Variables** section of the Supabase dashboard. Make sure `ALLOWED_ORIGINS` includes `http://localhost:3000` when developing locally.
+
 ---
 
 ## 📚 Main Sections


### PR DESCRIPTION
## Summary
- document AI tool environment variables
- add OPENAI_API_KEY, GEMINI_API_KEY and ALLOWED_ORIGINS to `.env.example`

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6886d5b03fb0832eaa679311386cc00c