### PR TITLE
Update Turnstile config

### DIFF
--- a/supabase/config.toml
+++ b/supabase/config.toml
@@ -6,3 +6,6 @@ verify_jwt = false
 
 [functions.get-hcaptcha-config]
 verify_jwt = false
+
+[functions.verify-turnstile]
+verify_jwt = false


### PR DESCRIPTION
## Summary
- allow public Turnstile verification in Supabase

## Testing
- `npm run lint`
- `npx vitest run` *(fails: ResizeObserver is not defined)*

------
https://chatgpt.com/codex/tasks/task_e_6886f51270c0832eb025a813e172a284