### PR TITLE
Add Turnstile env vars docs

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -16,7 +16,7 @@ NEWSLETTER_LOG_TABLE=newsletter_logs
 OPENAI_API_KEY=
 GEMINI_API_KEY=
 
-# Cloudflare Turnstile keys
+# Cloudflare Turnstile keys (optional)
 # Public site key used in the frontend
 VITE_CF_TURNSTILE_SITE_KEY=
 # Secret key used by the verification function

--- a/README.md
+++ b/README.md
@@ -72,6 +72,8 @@ Supabase project and optionally in a local `.env` file:
 OPENAI_API_KEY=your-openai-key
 GEMINI_API_KEY=your-gemini-key
 ALLOWED_ORIGINS=http://localhost:3000,https://zwanski.org
+VITE_CF_TURNSTILE_SITE_KEY=your-public-site-key
+CLOUDFLARE_TURNSTILE_SECRET_KEY=your-secret-key
 ```
 
 `ALLOWED_ORIGINS` controls which domains may call the edge functions.


### PR DESCRIPTION
## Summary
- document Cloudflare Turnstile variables near other optional settings
- mark the Turnstile keys section in `.env.example` as optional

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68870449f1a8832e8c8b3b492fc7071c