### PR TITLE
Remove hCaptcha script from index.html

### DIFF
--- a/index.html
+++ b/index.html
@@ -101,11 +101,7 @@
     }
     </script>
     <!-- End Schema.org -->
-    
     <!-- hCaptcha -->
-    <script src="https://js.hcaptcha.com/1/api.js" async defer></script>
-    
-
     <style>
 
       /* Ensure cookie banners always stay above other widgets */


### PR DESCRIPTION
## Summary
- remove the external hCaptcha script in `index.html`

## Testing
- `npm run lint` *(fails: Parsing error in `ber.ts`)*
- `npm run test` *(fails: unable to resolve import and test assertion errors)*

------
https://chatgpt.com/codex/tasks/task_e_6887044c9df4832e98524718fc476682