### PR TITLE
Add tool translations

### DIFF
--- a/src/context/translations/ar.ts
+++ b/src/context/translations/ar.ts
@@ -238,6 +238,14 @@ export const arTranslations = {
   "jobs.medium": "متوسط",
   "jobs.high": "عالي",
 
+  // Tools Section
+  "tools.passwordGenerator": "مولد كلمات المرور",
+  "tools.passwordGeneratorDesc": "إنشاء كلمات مرور عشوائية وآمنة",
+  "tools.qrGenerator": "مولد رمز QR",
+  "tools.qrGeneratorDesc": "إنشاء رموز QR للروابط والنصوص",
+  "tools.urlShortener": "أداة تقصير الروابط",
+  "tools.urlShortenerDesc": "قصّر الروابط الطويلة بسهولة",
+
   // Common
   "common.search": "البحث",
 

--- a/src/context/translations/ber.ts
+++ b/src/context/translations/ber.ts
@@ -238,6 +238,14 @@ export const berTranslations = {
   "jobs.medium": "Alemmas",
   "jobs.high": "Ameqqran",
 
+  // Tools Section
+  "tools.passwordGenerator": "Ameskar n wawalen uffiren",
+  "tools.passwordGeneratorDesc": "Rnu wawalen uffiren s tɣellist",
+  "tools.qrGenerator": "Ameskar QR",
+  "tools.qrGeneratorDesc": "Rnu tangalt QR i yisebtar d uḍris",
+  "tools.urlShortener": "Amezriḍ URL",
+  "tools.urlShortenerDesc": "Sseẓẓer isebtar iqqaren s uselḥi",
+
   // Common
   "common.search": "Anadi",
 

--- a/src/context/translations/en.ts
+++ b/src/context/translations/en.ts
@@ -238,6 +238,14 @@ export const enTranslations = {
   "jobs.medium": "Medium",
   "jobs.high": "High",
 
+  // Tools Section
+  "tools.passwordGenerator": "Password Generator",
+  "tools.passwordGeneratorDesc": "Generate secure, random passwords",
+  "tools.qrGenerator": "QR Code Generator",
+  "tools.qrGeneratorDesc": "Create QR codes for links and text",
+  "tools.urlShortener": "URL Shortener",
+  "tools.urlShortenerDesc": "Shorten long URLs easily",
+
   // Common
   "common.search": "Search",
 

--- a/src/context/translations/fr.ts
+++ b/src/context/translations/fr.ts
@@ -238,6 +238,14 @@ export const frTranslations = {
   "jobs.medium": "Moyen",
   "jobs.high": "Élevé",
 
+  // Tools Section
+  "tools.passwordGenerator": "Générateur de mots de passe",
+  "tools.passwordGeneratorDesc": "Générez des mots de passe sécurisés et aléatoires",
+  "tools.qrGenerator": "Générateur de QR code",
+  "tools.qrGeneratorDesc": "Créez des QR codes pour vos liens et textes",
+  "tools.urlShortener": "Raccourcisseur d'URL",
+  "tools.urlShortenerDesc": "Raccourcissez facilement les liens longs",
+
   // Common
   "common.search": "Rechercher",
 

--- a/src/context/translations/ha.ts
+++ b/src/context/translations/ha.ts
@@ -238,6 +238,14 @@ export const haTranslations = {
   "jobs.medium": "Matsakaici",
   "jobs.high": "Babba",
 
+  // Tools Section
+  "tools.passwordGenerator": "Mai Haifar da Kalmar sirri",
+  "tools.passwordGeneratorDesc": "Ƙirƙiri kalmomin sirri masu ƙarfi",
+  "tools.qrGenerator": "Mai Haifar da Lambar QR",
+  "tools.qrGeneratorDesc": "Ƙirƙiri lambobin QR don hanyoyi da rubutu",
+  "tools.urlShortener": "Takaita URL",
+  "tools.urlShortenerDesc": "Takaita dogayen hanyoyin yanar gizo cikin sauƙi",
+
   // Common
   "common.search": "Bincike",
 

--- a/tests/JSONFormatter.test.tsx
+++ b/tests/JSONFormatter.test.tsx
@@ -7,13 +7,14 @@ describe('JSONFormatter', () => {
     render(<JSONFormatter />);
     fireEvent.change(screen.getByRole('textbox'), { target: { value: '{"a":1}' } });
     fireEvent.click(screen.getByRole('button', { name: /format/i }));
-    expect(screen.getByTestId('result').textContent?.trim()).toBe('{\n  "a": 1\n}');
+    const outputs = screen.getAllByRole('textbox');
+    expect(outputs[1].value.trim()).toBe('{\n  "a": 1\n}');
   });
 
   it('shows error on invalid JSON', () => {
     render(<JSONFormatter />);
     fireEvent.change(screen.getByRole('textbox'), { target: { value: '{a}' } });
     fireEvent.click(screen.getByRole('button', { name: /format/i }));
-    expect(screen.getByRole('alert')).toHaveTextContent('Invalid JSON');
+    expect(screen.getByText('Invalid JSON')).toBeInTheDocument();
   });
 });

--- a/tests/PasswordGenerator.test.tsx
+++ b/tests/PasswordGenerator.test.tsx
@@ -8,6 +8,7 @@ describe('PasswordGenerator', () => {
     const lengthInput = screen.getByRole('spinbutton');
     fireEvent.change(lengthInput, { target: { value: '8' } });
     fireEvent.click(screen.getByText(/generate/i));
-    expect(screen.getByTestId('result').textContent).toHaveLength(8);
+    const output = screen.getByRole('textbox');
+    expect((output as HTMLInputElement).value).toHaveLength(8);
   });
 });

--- a/tests/Tools.test.tsx
+++ b/tests/Tools.test.tsx
@@ -7,6 +7,13 @@ vi.mock('@/components/Navbar', () => ({ default: () => <div>Navbar</div> }));
 vi.mock('@/components/Footer', () => ({ default: () => <div>Footer</div> }));
 vi.mock('@/components/IMEIChecker', () => ({ default: () => <div>IMEIChecker</div> }));
 vi.mock('@/components/SEOHelmet', () => ({ SEOHelmet: () => <></> }));
+vi.mock('@/components/PasswordGenerator', () => ({ default: () => <div>PasswordGenerator</div> }));
+vi.mock('@/components/QRCodeGenerator', () => ({ default: () => <div>QRCodeGenerator</div> }));
+vi.mock('@/components/URLShortener', () => ({ default: () => <div>URLShortener</div> }));
+vi.mock('@/components/ColorPicker', () => ({ default: () => <div>ColorPicker</div> }));
+vi.mock('@/components/JSONFormatter', () => ({ default: () => <div>JSONFormatter</div> }));
+vi.mock('@/components/TimezoneConverter', () => ({ default: () => <div>TimezoneConverter</div> }));
+vi.mock('@/components/ImageCompressor', () => ({ default: () => <div>ImageCompressor</div> }));
 
 import { LanguageProvider } from '@/context/LanguageContext';
 


### PR DESCRIPTION
## Summary
- add Tool section translations for various languages
- update tests to match current UI and mock components

## Testing
- `npm run lint`
- `npx vitest run`


------
https://chatgpt.com/codex/tasks/task_e_6887bbca73f4832ea3256b9514449dcd