### PR TITLE
Fix Blogger config errors

### DIFF
--- a/src/hooks/useBlogger.ts
+++ b/src/hooks/useBlogger.ts
@@ -26,7 +26,8 @@ export function useBlogger() {
       setNextPageToken(response.nextPageToken);
       setPrevPageToken(response.prevPageToken);
     } catch (err) {
-      setError(err instanceof Error ? err.message : 'Failed to fetch blog posts');
+      const message = err instanceof Error ? err.message : String(err);
+      setError(message);
       console.error('Error fetching posts:', err);
     } finally {
       setLoading(false);
@@ -48,7 +49,8 @@ export function useBlogger() {
       setNextPageToken(response.nextPageToken);
       setPrevPageToken(response.prevPageToken);
     } catch (err) {
-      setError(err instanceof Error ? err.message : 'Failed to search blog posts');
+      const message = err instanceof Error ? err.message : String(err);
+      setError(message);
       console.error('Error searching posts:', err);
     } finally {
       setLoading(false);
@@ -98,7 +100,8 @@ export function useBlogPost(postId: string) {
         const postData = await bloggerApi.getPost(postId);
         setPost(postData);
       } catch (err) {
-        setError(err instanceof Error ? err.message : 'Failed to fetch blog post');
+        const message = err instanceof Error ? err.message : String(err);
+        setError(message);
         console.error('Error fetching post:', err);
       } finally {
         setLoading(false);

--- a/src/services/bloggerApi.ts
+++ b/src/services/bloggerApi.ts
@@ -2,10 +2,14 @@ const BLOGGER_API_URL = 'https://www.googleapis.com/blogger/v3';
 const BLOG_ID: string | undefined = import.meta.env.VITE_BLOGGER_BLOG_ID;
 const API_KEY: string | undefined = import.meta.env.VITE_BLOGGER_API_KEY;
 
-const missingConfigError =
-  !API_KEY || !BLOG_ID
-    ? new Error('Blogger API key or Blog ID not configured')
+const missingConfigError = (() => {
+  const missing: string[] = [];
+  if (!API_KEY) missing.push('VITE_BLOGGER_API_KEY');
+  if (!BLOG_ID) missing.push('VITE_BLOGGER_BLOG_ID');
+  return missing.length
+    ? new Error(`Missing Blogger API configuration: ${missing.join(', ')}`)
     : null;
+})();
 
 function ensureEnv() {
   if (missingConfigError) {


### PR DESCRIPTION
## Summary
- surface Blogger API config errors
- show raw error messages in `useBlogger`

## Testing
- `npm run lint`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6887c596e5dc832eafd91efe7f43fc41