### PR TITLE
Add Blogger proxy function

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,6 +109,18 @@ Include `http://localhost:3000` when running the frontend locally to avoid
 CORS errors.
 ```
 
+### Supabase Blogger Proxy
+
+Use the `blogger-proxy` edge function when you don't want to expose your Blogger credentials in the frontend. Set these secrets in your Supabase project:
+
+```bash
+BLOGGER_API_KEY=your-api-key
+BLOGGER_BLOG_ID=your-blog-id
+ALLOWED_ORIGINS=http://localhost:3000,https://yourdomain.com
+```
+
+`ALLOWED_ORIGINS` should list the sites allowed to call the function.
+
 ## 💻 Development Setup
 
 Some React and Vite packages depend on slightly different peer versions. This

--- a/supabase/config.toml
+++ b/supabase/config.toml
@@ -6,3 +6,6 @@ verify_jwt = false
 
 [functions.get-hcaptcha-config]
 verify_jwt = false
+
+[functions.blogger-proxy]
+verify_jwt = false

--- a/supabase/functions/blogger-proxy/index.test.ts
+++ b/supabase/functions/blogger-proxy/index.test.ts
@@ -1,0 +1,35 @@
+import { describe, it, expect, beforeAll, vi } from 'vitest';
+import { loadFunction } from '../../../tests/loadFunction';
+
+let handler: (req: Request) => Promise<Response>;
+
+beforeAll(async () => {
+  (globalThis as any).Deno = { env: { get: (k: string) => process.env[k] } };
+  handler = await loadFunction('supabase/functions/blogger-proxy/index.ts');
+});
+
+describe('blogger-proxy', () => {
+  it('returns config error when secrets missing', async () => {
+    delete process.env.BLOGGER_API_KEY;
+    delete process.env.BLOGGER_BLOG_ID;
+    const req = new Request('http://localhost/posts', { method: 'POST', body: '{}' });
+    const res = await handler(req);
+    expect(res.status).toBe(500);
+    const json = await res.json();
+    expect(json.error).toContain('Server configuration error');
+  });
+
+  it('proxies list posts', async () => {
+    process.env.BLOGGER_API_KEY = 'a';
+    process.env.BLOGGER_BLOG_ID = 'b';
+    const fetchMock = vi.fn(async () => new Response('{"items":[]}', { status: 200 }));
+    (globalThis as any).fetch = fetchMock;
+    const req = new Request('http://localhost/posts', { method: 'POST', body: '{}' });
+    const res = await handler(req);
+    expect(res.status).toBe(200);
+    const url = fetchMock.mock.calls[0][0] as string;
+    expect(url).toContain('/blogs/b/posts?');
+    const json = await res.json();
+    expect(json.items).toBeDefined();
+  });
+});

--- a/supabase/functions/blogger-proxy/index.ts
+++ b/supabase/functions/blogger-proxy/index.ts
@@ -1,0 +1,100 @@
+import { serve } from "https://deno.land/std@0.190.0/http/server.ts";
+
+const ALLOWED_ORIGINS = Deno.env.get("ALLOWED_ORIGINS") ?? "https://zwanski.org";
+const BLOGGER_API_KEY = Deno.env.get("BLOGGER_API_KEY");
+const BLOGGER_BLOG_ID = Deno.env.get("BLOGGER_BLOG_ID");
+const BLOGGER_API_URL = "https://www.googleapis.com/blogger/v3";
+
+const corsHeaders = {
+  "Access-Control-Allow-Origin": ALLOWED_ORIGINS,
+  "Access-Control-Allow-Headers": "authorization, x-client-info, apikey, content-type",
+};
+
+async function handleList(body: any) {
+  const params = new URLSearchParams({
+    key: BLOGGER_API_KEY!,
+    orderBy: "published",
+    fetchImages: "true",
+    fetchBodies: "true",
+    maxResults: String(body?.maxResults ?? 12),
+  });
+  if (body?.pageToken) params.append("pageToken", body.pageToken);
+  const res = await fetch(`${BLOGGER_API_URL}/blogs/${BLOGGER_BLOG_ID}/posts?${params}`);
+  if (!res.ok) throw new Error(`HTTP error: ${res.status}`);
+  const data = await res.json();
+  return {
+    items: data.items || [],
+    nextPageToken: data.nextPageToken,
+    prevPageToken: data.prevPageToken,
+  };
+}
+
+async function handleGet(postId: string) {
+  const params = new URLSearchParams({
+    key: BLOGGER_API_KEY!,
+    fetchImages: "true",
+    fetchBodies: "true",
+  });
+  const res = await fetch(`${BLOGGER_API_URL}/blogs/${BLOGGER_BLOG_ID}/posts/${postId}?${params}`);
+  if (!res.ok) throw new Error(`HTTP error: ${res.status}`);
+  return await res.json();
+}
+
+async function handleSearch(body: any) {
+  const params = new URLSearchParams({
+    key: BLOGGER_API_KEY!,
+    q: body?.query ?? "",
+    orderBy: "published",
+    fetchImages: "true",
+    fetchBodies: "true",
+    maxResults: String(body?.maxResults ?? 12),
+  });
+  const res = await fetch(`${BLOGGER_API_URL}/blogs/${BLOGGER_BLOG_ID}/posts/search?${params}`);
+  if (!res.ok) throw new Error(`HTTP error: ${res.status}`);
+  const data = await res.json();
+  return {
+    items: data.items || [],
+    nextPageToken: data.nextPageToken,
+    prevPageToken: data.prevPageToken,
+  };
+}
+
+serve(async (req) => {
+  if (req.method === "OPTIONS") {
+    return new Response(null, { headers: corsHeaders });
+  }
+
+  if (!BLOGGER_API_KEY || !BLOGGER_BLOG_ID) {
+    return new Response(
+      JSON.stringify({ error: "Server configuration error" }),
+      { status: 500, headers: { ...corsHeaders, "Content-Type": "application/json" } }
+    );
+  }
+
+  const url = new URL(req.url);
+  const segments = url.pathname.replace(/^\/blogger-proxy/, "").split("/").filter(Boolean);
+  try {
+    let result;
+    if (segments[0] === "posts" && segments.length === 1) {
+      const body = await req.json().catch(() => ({}));
+      result = await handleList(body);
+    } else if (segments[0] === "posts" && segments.length === 2) {
+      result = await handleGet(segments[1]);
+    } else if (segments[0] === "search") {
+      const body = await req.json().catch(() => ({}));
+      result = await handleSearch(body);
+    } else {
+      return new Response("Not Found", { status: 404, headers: corsHeaders });
+    }
+
+    return new Response(JSON.stringify(result), {
+      headers: { ...corsHeaders, "Content-Type": "application/json" },
+    });
+  } catch (err) {
+    console.error("blogger-proxy error", err);
+    return new Response(
+      JSON.stringify({ error: "Internal server error" }),
+      { status: 500, headers: { ...corsHeaders, "Content-Type": "application/json" } }
+    );
+  }
+});

--- a/tests/bloggerApi.test.ts
+++ b/tests/bloggerApi.test.ts
@@ -1,0 +1,58 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+
+vi.mock('@/integrations/supabase/client', () => ({
+  supabase: {
+    functions: {
+      invoke: vi.fn(),
+    },
+  },
+}));
+
+async function getSupabase() {
+  const mod = await import('@/integrations/supabase/client');
+  return mod.supabase;
+}
+
+const originalEnv = { ...process.env };
+
+async function loadApi() {
+  const mod = await import('@/services/bloggerApi');
+  return mod.bloggerApi;
+}
+
+beforeEach(async () => {
+  Object.assign(process.env, originalEnv);
+  vi.resetModules();
+  const supabase = await getSupabase();
+  (supabase.functions.invoke as any).mockClear();
+});
+
+afterEach(() => {
+  Object.assign(process.env, originalEnv);
+});
+
+describe('bloggerApi', () => {
+  it('falls back to edge function when config missing', async () => {
+    delete (process.env as any).VITE_BLOGGER_API_KEY;
+    delete (process.env as any).VITE_BLOGGER_BLOG_ID;
+    const api = await loadApi();
+    const supabase = await getSupabase();
+    (supabase.functions.invoke as any).mockResolvedValue({ data: { items: [] } });
+    await api.getPosts();
+    expect(supabase.functions.invoke).toHaveBeenCalledWith('blogger-proxy/posts', {
+      body: { maxResults: 12 },
+    });
+  });
+
+  it('uses direct fetch when config present', async () => {
+    process.env.VITE_BLOGGER_API_KEY = 'x';
+    process.env.VITE_BLOGGER_BLOG_ID = 'y';
+    const fetchMock = vi.fn(async () => new Response('{"items":[]}', { status: 200 }));
+    (globalThis as any).fetch = fetchMock;
+    const api = await loadApi();
+    const supabase = await getSupabase();
+    await api.getPosts();
+    expect(fetchMock).toHaveBeenCalled();
+    expect(supabase.functions.invoke).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Summary
- add new `blogger-proxy` Edge Function for Blogger API access
- call the proxy from `bloggerApi` when env vars are missing
- disable JWT verification for `blogger-proxy`
- document the new secrets
- add unit tests for the proxy and service

## Testing
- `npm run lint`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6887d5e60e74832ea73f5c125dabf8d8