### PR TITLE
Add Supabase blogger proxy

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,6 +109,18 @@ Include `http://localhost:3000` when running the frontend locally to avoid
 CORS errors.
 ```
 
+## Supabase Blogger Proxy
+
+If the frontend doesn't have direct Blogger API credentials, it falls back to a
+Supabase edge function that proxies requests. Set these secrets in your Supabase
+project so the `blogger-proxy` function can operate:
+
+```bash
+BLOGGER_API_KEY=your-blogger-key
+BLOGGER_BLOG_ID=your-blog-id
+ALLOWED_ORIGINS=http://localhost:3000,https://zwanski.org
+```
+
 ## 💻 Development Setup
 
 Some React and Vite packages depend on slightly different peer versions. This

--- a/supabase/config.toml
+++ b/supabase/config.toml
@@ -6,3 +6,6 @@ verify_jwt = false
 
 [functions.get-hcaptcha-config]
 verify_jwt = false
+
+[functions.blogger-proxy]
+verify_jwt = false

--- a/supabase/functions/blogger-proxy/index.test.ts
+++ b/supabase/functions/blogger-proxy/index.test.ts
@@ -1,0 +1,22 @@
+import { describe, it, expect, beforeAll, vi } from 'vitest';
+import { loadFunction } from '../../../tests/loadFunction';
+
+let handler: (req: Request) => Promise<Response>;
+
+beforeAll(async () => {
+  (globalThis as any).Deno = { env: { get: (k: string) => process.env[k] } };
+  handler = await loadFunction('supabase/functions/blogger-proxy/index.ts');
+});
+
+describe('blogger-proxy', () => {
+  it('forwards list posts request', async () => {
+    process.env.BLOGGER_API_KEY = 'x';
+    process.env.BLOGGER_BLOG_ID = '1';
+    const fetchMock = vi.fn(async () => new Response('{"items":[]}', { status: 200 }));
+    (globalThis as any).fetch = fetchMock;
+
+    const res = await handler(new Request('http://localhost/posts'));
+    expect(res.status).toBe(200);
+    expect(fetchMock).toHaveBeenCalled();
+  });
+});

--- a/supabase/functions/blogger-proxy/index.ts
+++ b/supabase/functions/blogger-proxy/index.ts
@@ -1,0 +1,87 @@
+import { serve } from "https://deno.land/std@0.190.0/http/server.ts";
+
+const ALLOWED_ORIGINS = Deno.env.get("ALLOWED_ORIGINS") ?? "https://zwanski.org";
+const BLOGGER_API_KEY = Deno.env.get("BLOGGER_API_KEY");
+const BLOGGER_BLOG_ID = Deno.env.get("BLOGGER_BLOG_ID");
+const BLOGGER_API_URL = "https://www.googleapis.com/blogger/v3";
+
+const corsHeaders = {
+  "Access-Control-Allow-Origin": ALLOWED_ORIGINS,
+  "Access-Control-Allow-Headers": "authorization, x-client-info, apikey, content-type",
+};
+
+function buildError(status: number, message: string) {
+  return new Response(JSON.stringify({ error: message }), {
+    status,
+    headers: { ...corsHeaders, "Content-Type": "application/json" },
+  });
+}
+
+async function fetchFromBlogger(path: string, params: URLSearchParams) {
+  if (!BLOGGER_API_KEY || !BLOGGER_BLOG_ID) {
+    return buildError(500, "Server configuration error");
+  }
+  params.set("key", BLOGGER_API_KEY);
+  const url = `${BLOGGER_API_URL}/blogs/${BLOGGER_BLOG_ID}${path}?${params}`;
+  const res = await fetch(url);
+  if (!res.ok) {
+    throw new Error(`HTTP error! status: ${res.status}`);
+  }
+  const data = await res.json();
+  return new Response(JSON.stringify(data), {
+    headers: { ...corsHeaders, "Content-Type": "application/json" },
+  });
+}
+
+serve(async (req) => {
+  if (req.method === "OPTIONS") {
+    return new Response(null, { headers: corsHeaders });
+  }
+
+  const url = new URL(req.url);
+  let path = url.pathname;
+  if (path.startsWith("/blogger-proxy")) {
+    path = path.slice("/blogger-proxy".length);
+  }
+
+  try {
+    if (path === "/posts") {
+      const params = new URLSearchParams({
+        maxResults: url.searchParams.get("maxResults") ?? "12",
+        orderBy: "published",
+        fetchImages: "true",
+        fetchBodies: "true",
+      });
+      const pageToken = url.searchParams.get("pageToken");
+      if (pageToken) params.set("pageToken", pageToken);
+      return await fetchFromBlogger("/posts", params);
+    }
+
+    const postMatch = path.match(/^\/posts\/(.+)$/);
+    if (postMatch) {
+      const params = new URLSearchParams({ fetchImages: "true", fetchBodies: "true" });
+      return await fetchFromBlogger(`/posts/${postMatch[1]}`, params);
+    }
+
+    if (path === "/search") {
+      const query = url.searchParams.get("q");
+      if (!query) {
+        return buildError(400, "Missing search query");
+      }
+      const params = new URLSearchParams({
+        q: query,
+        maxResults: url.searchParams.get("maxResults") ?? "12",
+        orderBy: "published",
+        fetchImages: "true",
+        fetchBodies: "true",
+      });
+      return await fetchFromBlogger("/posts/search", params);
+    }
+
+    return buildError(404, "Not found");
+  } catch (err) {
+    console.error("blogger-proxy error", err);
+    return buildError(500, "Internal server error");
+  }
+});
+

--- a/tests/bloggerApi.test.ts
+++ b/tests/bloggerApi.test.ts
@@ -1,0 +1,28 @@
+import { describe, it, expect, vi } from 'vitest';
+
+async function importApi(vars: Record<string, string | undefined>) {
+  for (const key of Object.keys(vars)) {
+    if (vars[key] === undefined) delete process.env[key];
+    else process.env[key] = vars[key] as string;
+  }
+  vi.resetModules();
+  return await import('../src/services/bloggerApi.ts');
+}
+
+describe('bloggerApi', () => {
+  it('uses edge function when config missing', async () => {
+    const fetchMock = vi.fn(async () => new Response('{"items":[]}', { status: 200 }));
+    (globalThis as any).fetch = fetchMock;
+    const { bloggerApi } = await importApi({ VITE_BLOGGER_API_KEY: '', VITE_BLOGGER_BLOG_ID: '' });
+    await bloggerApi.getPosts();
+    expect(fetchMock.mock.calls[0][0]).toContain('/blogger-proxy/posts');
+  });
+
+  it('uses Blogger API when config present', async () => {
+    const fetchMock = vi.fn(async () => new Response('{"items":[]}', { status: 200 }));
+    (globalThis as any).fetch = fetchMock;
+    const { bloggerApi } = await importApi({ VITE_BLOGGER_API_KEY: 'k', VITE_BLOGGER_BLOG_ID: 'b' });
+    await bloggerApi.getPosts();
+    expect(fetchMock.mock.calls[0][0]).toContain('googleapis.com');
+  });
+});


### PR DESCRIPTION
## Summary
- add `blogger-proxy` edge function
- allow unauthenticated access in `config.toml`
- fall back to the edge function in `bloggerApi` when env vars are missing
- document Supabase Blogger Proxy secrets in README
- test new proxy behaviour

## Testing
- `npm run lint`
- `npm run test`


------
https://chatgpt.com/codex/tasks/task_e_6887d95f815c832ebf0bc91b0d66cc2b