### PR TITLE
Add Migrant Support nav item

### DIFF
--- a/src/components/Navbar.tsx
+++ b/src/components/Navbar.tsx
@@ -14,7 +14,8 @@ import {
   FileText,
   MessageSquare,
   Bot,
-  Activity
+  Activity,
+  Globe
 } from "lucide-react";
 import ZwanskiLogo from "./ZwanskiLogo";
 import { ThemeToggle } from "./ThemeToggle";
@@ -127,6 +128,7 @@ const Navbar = () => {
     { label: "Tools", path: "/tools", icon: Settings2 },
     { label: "Jobs", path: "/jobs", icon: Briefcase },
     { label: "Blog", path: "/blog", icon: FileText },
+    { label: "Migrant Support", path: "/migrant-support", icon: Globe },
     { label: "Chat", path: "/chat", icon: MessageSquare },
     { label: "Threat Map", path: "/threat-map", icon: Activity },
     { label: "AI", path: "/ai", icon: Bot },

--- a/src/components/navbar/DesktopNavigation.tsx
+++ b/src/components/navbar/DesktopNavigation.tsx
@@ -1,7 +1,24 @@
 import React from "react";
 import { Link, useLocation } from "react-router-dom";
 import { Button } from "@/components/ui/button";
-import { Shield, Home, Wrench, GraduationCap, Briefcase, Users, MessageSquare, Mail, Settings, BookOpen, Info, FileText, LifeBuoy, Rss, PenTool } from "lucide-react";
+import {
+  Shield,
+  Home,
+  Wrench,
+  GraduationCap,
+  Briefcase,
+  Users,
+  MessageSquare,
+  Mail,
+  Settings,
+  BookOpen,
+  Info,
+  FileText,
+  LifeBuoy,
+  Rss,
+  PenTool,
+  Globe
+} from "lucide-react";
 import { useAuth } from "@/context/AuthContext";
 
 const navItems = [
@@ -17,6 +34,7 @@ const navItems = [
   { label: "3D Model", path: "/3d", icon: BookOpen },
   { label: "About", path: "/about", icon: Info },
   { label: "FAQ", path: "/faq", icon: FileText },
+  { label: "Migrant Support", path: "/migrant-support", icon: Globe },
   { label: "Support", path: "/support", icon: LifeBuoy },
   { label: "Infrastructure", path: "/infrastructure" },
   { label: "Privacy", path: "/privacy-policy" },

--- a/src/components/navbar/MobileNavigation.tsx
+++ b/src/components/navbar/MobileNavigation.tsx
@@ -2,7 +2,24 @@ import React from "react";
 import { Link, useLocation } from "react-router-dom";
 import { Button } from "@/components/ui/button";
 import { useAuth } from "@/context/AuthContext";
-import { Shield, Home, Wrench, GraduationCap, Briefcase, Users, MessageSquare, Mail, Settings, BookOpen, Info, FileText, LifeBuoy, Rss, PenTool } from "lucide-react";
+import {
+  Shield,
+  Home,
+  Wrench,
+  GraduationCap,
+  Briefcase,
+  Users,
+  MessageSquare,
+  Mail,
+  Settings,
+  BookOpen,
+  Info,
+  FileText,
+  LifeBuoy,
+  Rss,
+  PenTool,
+  Globe
+} from "lucide-react";
 
 const navItems = [
   { label: "Home", path: "/", icon: Home },
@@ -17,6 +34,7 @@ const navItems = [
   { label: "3D Model", path: "/3d", icon: BookOpen },
   { label: "About", path: "/about", icon: Info },
   { label: "FAQ", path: "/faq", icon: FileText },
+  { label: "Migrant Support", path: "/migrant-support", icon: Globe },
   { label: "Support", path: "/support", icon: LifeBuoy },
   { label: "Infrastructure", path: "/infrastructure" },
   { label: "Privacy", path: "/privacy-policy" },


### PR DESCRIPTION
## Summary
- add `Migrant Support` item to main navigation and imports
- include new entry in desktop and mobile nav menus
- run lint (fails) and build

## Testing
- `npm run lint` *(fails: Unexpected any)*
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68882ce72178832e8a7410ec2faa902a