### PR TITLE
Add Migrant Support route

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -4,6 +4,7 @@ import { TooltipProvider } from "@/components/ui/tooltip";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { BrowserRouter, Routes, Route } from "react-router-dom";
 import { Helmet, HelmetProvider } from "react-helmet-async";
+import MigrantSupport from "./pages/MigrantSupport";
 
 // Context Providers
 import { ThemeProvider } from "@/context/ThemeContext";
@@ -184,6 +185,7 @@ function App() {
                           <Route path="/terms-of-service" element={<TermsOfService />} />
                           
                           <Route path="/support" element={<Support />} />
+                          <Route path="/migrant-support" element={<MigrantSupport />} />
                           <Route path="/faq" element={<FAQ />} />
                           <Route path="/infrastructure" element={<Infrastructure />} />
                           <Route path="/imei-check" element={<IMEICheck />} />

--- a/src/pages/MigrantSupport.tsx
+++ b/src/pages/MigrantSupport.tsx
@@ -1,0 +1,32 @@
+import Navbar from "@/components/Navbar";
+import Footer from "@/components/Footer";
+import { Helmet } from "react-helmet-async";
+
+const MigrantSupport = () => {
+  return (
+    <div className="flex flex-col min-h-screen bg-background">
+      <Helmet>
+        <title>Migrant Support - Zwanski Tech</title>
+        <meta
+          name="description"
+          content="Resources and services for migrants provided by Zwanski Tech."
+        />
+      </Helmet>
+
+      <Navbar />
+
+      <main className="flex-1 axeptio-section">
+        <div className="axeptio-container text-center">
+          <h1 className="axeptio-heading mb-4">Migrant Support</h1>
+          <p className="text-muted-foreground">
+            This page provides dedicated resources for migrants and newcomers.
+          </p>
+        </div>
+      </main>
+
+      <Footer />
+    </div>
+  );
+};
+
+export default MigrantSupport;


### PR DESCRIPTION
## Summary
- add new `MigrantSupport` page
- wire migrant support route in `App.tsx`

## Testing
- `npm run lint` *(fails: cannot pass lint due to existing repo errors)*

------
https://chatgpt.com/codex/tasks/task_e_68882ce6927c832eb78895ec0a39c546