### PR TITLE
Centralize navigation items

### DIFF
--- a/src/components/Navbar.tsx
+++ b/src/components/Navbar.tsx
@@ -2,21 +2,14 @@ import React, { useState, useEffect } from "react";
 import { useNavigate, useLocation } from "react-router-dom";
 import { useAuth } from "@/context/AuthContext";
 import { Button } from "@/components/ui/button";
+import { Menu, X } from "lucide-react";
 import {
-  Menu,
-  X,
-  Home,
-  Wrench,
-  Shield,
-  GraduationCap,
-  Briefcase,
-  Settings2,
-  FileText,
-  MessageSquare,
-  Bot,
-  Activity,
-  Globe
-} from "lucide-react";
+  DropdownMenu,
+  DropdownMenuTrigger,
+  DropdownMenuContent,
+  DropdownMenuItem,
+} from "@/components/ui/dropdown-menu";
+import { navItems, NAV_DISPLAY_LIMIT } from "./navbar/navItems";
 import ZwanskiLogo from "./ZwanskiLogo";
 import { ThemeToggle } from "./ThemeToggle";
 import { LanguageSelector } from "./LanguageSelector";
@@ -92,41 +85,6 @@ const Navbar = () => {
 
   const isActivePath = (path: string) => location.pathname === path;
 
-  const mainNavItems = [
-    { label: "Home", path: "/", icon: Home },
-    {
-      label: "Fix",
-      path: "/services?category=repair",
-      icon: Wrench,
-      description: "Device Repair & Recovery"
-    },
-    {
-      label: "Build",
-      path: "/services?category=development",
-      icon: Briefcase,
-      description: "Custom Development"
-    },
-    {
-      label: "Secure",
-      path: "/services?category=security",
-      icon: Shield,
-      description: "Cybersecurity Solutions"
-    },
-    {
-      label: "Teach",
-      path: "/academy",
-      icon: GraduationCap,
-      description: "Education & Training"
-    },
-    { label: "Tools", path: "/tools", icon: Settings2 },
-    { label: "Jobs", path: "/jobs", icon: Briefcase },
-    { label: "Blog", path: "/blog", icon: FileText },
-    { label: "Migrant Support", path: "/migrant-support", icon: Globe },
-    { label: "Chat", path: "/chat", icon: MessageSquare },
-    { label: "Threat Map", path: "/threat-map", icon: Activity },
-    { label: "AI", path: "/ai", icon: Bot }
-  ];
-
   return (
     <nav className="sticky top-0 z-50 bg-background/80 backdrop-blur-md border-b border-border/50">
       <div className="container mx-auto px-4">
@@ -201,7 +159,7 @@ const Navbar = () => {
                 <Menu className="h-4 w-4" />
                 All Services
               </Button>
-              {mainNavItems.slice(0, 6).map((item) => {
+              {navItems.slice(0, NAV_DISPLAY_LIMIT).map((item) => {
                 const Icon = item.icon;
                 return (
                   <Button
@@ -221,6 +179,28 @@ const Navbar = () => {
                   </Button>
                 );
               })}
+              {navItems.length > NAV_DISPLAY_LIMIT && (
+                <DropdownMenu>
+                  <DropdownMenuTrigger asChild>
+                    <Button variant="ghost" size="sm" className="nav-btn">
+                      More
+                    </Button>
+                  </DropdownMenuTrigger>
+                  <DropdownMenuContent>
+                    {navItems.slice(NAV_DISPLAY_LIMIT).map((item) => {
+                      const Icon = item.icon;
+                      return (
+                        <DropdownMenuItem asChild key={item.path}>
+                          <Link to={item.path} className="flex items-center gap-2">
+                            {Icon && <Icon className="h-4 w-4" />}
+                            {item.label}
+                          </Link>
+                        </DropdownMenuItem>
+                      );
+                    })}
+                  </DropdownMenuContent>
+                </DropdownMenu>
+              )}
             </div>
             <div className="flex items-center space-x-2 text-sm">
               <Button
@@ -277,7 +257,7 @@ const Navbar = () => {
                   SERVICES
                 </h3>
                 <div className="grid grid-cols-2 gap-1">
-                  {mainNavItems.slice(1, 5).map((item) => {
+                  {navItems.slice(1, 5).map((item) => {
                     const Icon = item.icon;
                     return (
                       <Button
@@ -310,7 +290,7 @@ const Navbar = () => {
                   EXPLORE
                 </h3>
                 <div className="space-y-1">
-                  {mainNavItems.slice(5).map((item) => {
+                  {navItems.slice(5).map((item) => {
                     const Icon = item.icon;
                     return (
                       <Button

--- a/src/components/navbar/DesktopNavigation.tsx
+++ b/src/components/navbar/DesktopNavigation.tsx
@@ -1,46 +1,9 @@
 import React from "react";
 import { Link, useLocation } from "react-router-dom";
 import { Button } from "@/components/ui/button";
-import {
-  Shield,
-  Home,
-  Wrench,
-  GraduationCap,
-  Briefcase,
-  Users,
-  MessageSquare,
-  Mail,
-  Settings,
-  BookOpen,
-  Info,
-  FileText,
-  LifeBuoy,
-  Rss,
-  PenTool,
-  Globe
-} from "lucide-react";
+import { Shield } from "lucide-react";
 import { useAuth } from "@/context/AuthContext";
-
-const navItems = [
-  { label: "Home", path: "/", icon: Home },
-  { label: "Services", path: "/services", icon: Wrench },
-  { label: "Academy", path: "/academy", icon: GraduationCap },
-  { label: "Jobs", path: "/jobs", icon: Briefcase },
-  { label: "Freelancers", path: "/freelancers", icon: Users },
-  { label: "Blog", path: "/blog", icon: PenTool },
-  { label: "Chat", path: "/chat", icon: MessageSquare },
-  { label: "Newsletter", path: "/newsletter", icon: Mail },
-  { label: "Tools", path: "/tools", icon: Settings },
-  { label: "3D Model", path: "/3d", icon: BookOpen },
-  { label: "About", path: "/about", icon: Info },
-  { label: "FAQ", path: "/faq", icon: FileText },
-  { label: "Migrant Support", path: "/migrant-support", icon: Globe },
-  { label: "Support", path: "/support", icon: LifeBuoy },
-  { label: "Infrastructure", path: "/infrastructure" },
-  { label: "Privacy", path: "/privacy-policy" },
-  { label: "Terms", path: "/terms-of-service" },
-  { label: "RSS", path: "/rss", icon: Rss },
-];
+import { navItems } from "./navItems";
 
 export default function DesktopNavigation() {
   const { isAuthenticated } = useAuth();

--- a/src/components/navbar/MobileNavigation.tsx
+++ b/src/components/navbar/MobileNavigation.tsx
@@ -2,45 +2,9 @@ import React from "react";
 import { Link, useLocation } from "react-router-dom";
 import { Button } from "@/components/ui/button";
 import { useAuth } from "@/context/AuthContext";
-import {
-  Shield,
-  Home,
-  Wrench,
-  GraduationCap,
-  Briefcase,
-  Users,
-  MessageSquare,
-  Mail,
-  Settings,
-  BookOpen,
-  Info,
-  FileText,
-  LifeBuoy,
-  Rss,
-  PenTool,
-  Globe
-} from "lucide-react";
+import { Shield } from "lucide-react";
+import { navItems } from "./navItems";
 
-const navItems = [
-  { label: "Home", path: "/", icon: Home },
-  { label: "Services", path: "/services", icon: Wrench },
-  { label: "Academy", path: "/academy", icon: GraduationCap },
-  { label: "Jobs", path: "/jobs", icon: Briefcase },
-  { label: "Freelancers", path: "/freelancers", icon: Users },
-  { label: "Blog", path: "/blog", icon: PenTool },
-  { label: "Chat", path: "/chat", icon: MessageSquare },
-  { label: "Newsletter", path: "/newsletter", icon: Mail },
-  { label: "Tools", path: "/tools", icon: Settings },
-  { label: "3D Model", path: "/3d", icon: BookOpen },
-  { label: "About", path: "/about", icon: Info },
-  { label: "FAQ", path: "/faq", icon: FileText },
-  { label: "Migrant Support", path: "/migrant-support", icon: Globe },
-  { label: "Support", path: "/support", icon: LifeBuoy },
-  { label: "Infrastructure", path: "/infrastructure" },
-  { label: "Privacy", path: "/privacy-policy" },
-  { label: "Terms", path: "/terms-of-service" },
-  { label: "RSS", path: "/rss", icon: Rss },
-];
 
 export default function MobileNavigation({ onNavigate }: { onNavigate?: () => void }) {
   const { isAuthenticated, user } = useAuth();

--- a/src/components/navbar/navItems.ts
+++ b/src/components/navbar/navItems.ts
@@ -1,0 +1,78 @@
+import {
+  Activity,
+  Bot,
+  BookOpen,
+  Briefcase,
+  FileText,
+  Globe,
+  GraduationCap,
+  Home,
+  LifeBuoy,
+  Mail,
+  MessageSquare,
+  PenTool,
+  Phone,
+  Rss,
+  Settings,
+  Settings2,
+  Shield,
+  Wrench,
+  Users,
+  Info,
+} from "lucide-react";
+
+export interface NavItem {
+  label: string;
+  path: string;
+  icon?: React.ComponentType<{ className?: string }>;
+  description?: string;
+}
+
+export const navItems: NavItem[] = [
+  { label: "Home", path: "/", icon: Home },
+  {
+    label: "Fix",
+    path: "/services?category=repair",
+    icon: Wrench,
+    description: "Device Repair & Recovery",
+  },
+  {
+    label: "Build",
+    path: "/services?category=development",
+    icon: Briefcase,
+    description: "Custom Development",
+  },
+  {
+    label: "Secure",
+    path: "/services?category=security",
+    icon: Shield,
+    description: "Cybersecurity Solutions",
+  },
+  {
+    label: "Teach",
+    path: "/academy",
+    icon: GraduationCap,
+    description: "Education & Training",
+  },
+  { label: "Tools", path: "/tools", icon: Settings2 },
+  { label: "Jobs", path: "/jobs", icon: Briefcase },
+  { label: "Blog", path: "/blog", icon: PenTool },
+  { label: "Freelancers", path: "/freelancers", icon: Users },
+  { label: "Chat", path: "/chat", icon: MessageSquare },
+  { label: "Newsletter", path: "/newsletter", icon: Mail },
+  { label: "3D Model", path: "/3d", icon: BookOpen },
+  { label: "Migrant Support", path: "/migrant-support", icon: Globe },
+  { label: "Support", path: "/support", icon: LifeBuoy },
+  { label: "Threat Map", path: "/threat-map", icon: Activity },
+  { label: "AI", path: "/ai", icon: Bot },
+  { label: "About", path: "/about", icon: Info },
+  { label: "FAQ", path: "/faq", icon: FileText },
+  { label: "IMEI Check", path: "/imei-check", icon: Phone },
+  { label: "Infrastructure", path: "/infrastructure" },
+  { label: "Privacy Policy", path: "/privacy-policy" },
+  { label: "Terms of Service", path: "/terms-of-service" },
+  { label: "RSS", path: "/rss", icon: Rss },
+];
+
+export const NAV_DISPLAY_LIMIT = 7;
+


### PR DESCRIPTION
## Summary
- centralize all navigation routes in `navItems.ts`
- reference `navItems` from `DesktopNavigation`, `MobileNavigation` and main `Navbar`
- show extra links under a `More` dropdown on large screens

## Testing
- `npm run lint` *(fails: Unexpected any, etc.)*
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68883b71c210832e88c40c04fa2a8585