### PR TITLE
Fix contribution guide duplication

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,1 +1,3 @@
-contributing files here
+# 🧭 Contributing to Zwanski-Tech
+
+... (trimmed)

--- a/Contributing.md
+++ b/Contributing.md
@@ -1,3 +1,0 @@
-# 🧭 Contributing to Zwanski-Tech
-
-... (trimmed)

--- a/README.md
+++ b/README.md
@@ -104,6 +104,8 @@ The script attempts to sign in with the provided credentials and then signs out,
 
 ## 📝 Contribution Guidelines
 
+See [CONTRIBUTING.md](CONTRIBUTING.md) for full guidelines.
+
 We welcome pull requests! To contribute:
 
 1. Fork this repository and create a new branch for your changes.


### PR DESCRIPTION
## Summary
- remove the placeholder `CONTRIBUTING.md`
- keep the existing `Contributing.md` content as `CONTRIBUTING.md`
- link to the guide from README

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68883ffb6368832ea855288ad38d59ca