### PR TITLE
Fix README clone URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ Welcome to the Zwanski Tech platform! This project powers [zwanski.org](https://
 ## 🏁 Getting Started
 
 ```bash
-git clone https://https://github.com/zwanski2019/ZWANSKI-TECH.git
+git clone https://github.com/zwanski2019/ZWANSKI-TECH.git
 cd ZWANSKI-TECH
 npm install
 npm run dev


### PR DESCRIPTION
## Summary
- correct the repository clone URL in README

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68883ff7a6bc832e8209ca58c932bd78