### PR TITLE
Add subscription fields to profiles

### DIFF
--- a/src/integrations/supabase/types.ts
+++ b/src/integrations/supabase/types.ts
@@ -2026,6 +2026,9 @@ export type Database = {
           user_type: Database["public"]["Enums"]["user_type"]
           verified: boolean | null
           website: string | null
+          subscription_status: string | null
+          subscription_start_date: string | null
+          subscription_end_date: string | null
           years_experience: number | null
         }
         Insert: {
@@ -2065,6 +2068,9 @@ export type Database = {
           user_type: Database["public"]["Enums"]["user_type"]
           verified?: boolean | null
           website?: string | null
+          subscription_status?: string | null
+          subscription_start_date?: string | null
+          subscription_end_date?: string | null
           years_experience?: number | null
         }
         Update: {
@@ -2104,6 +2110,9 @@ export type Database = {
           user_type?: Database["public"]["Enums"]["user_type"]
           verified?: boolean | null
           website?: string | null
+          subscription_status?: string | null
+          subscription_start_date?: string | null
+          subscription_end_date?: string | null
           years_experience?: number | null
         }
         Relationships: []

--- a/supabase/migrations/20250731165135_12e398c2-3aa1-45b4-922f-b83bed37fc6f.sql
+++ b/supabase/migrations/20250731165135_12e398c2-3aa1-45b4-922f-b83bed37fc6f.sql
@@ -1,0 +1,10 @@
+-- Add subscription fields to profiles
+ALTER TABLE public.profiles
+  ADD COLUMN subscription_status VARCHAR(20),
+  ADD COLUMN subscription_start_date TIMESTAMPTZ,
+  ADD COLUMN subscription_end_date TIMESTAMPTZ;
+
+-- Ensure RLS allows users to read their own subscription info
+CREATE POLICY IF NOT EXISTS "Users can view their own subscription fields" ON public.profiles
+  FOR SELECT TO authenticated
+  USING (auth.uid() = id);


### PR DESCRIPTION
## Summary
- add migration to add subscription fields to `public.profiles`
- update Supabase types with the new profile fields
- include an RLS policy ensuring authenticated users can read their own subscription info

## Testing
- `npm run lint` *(fails: Unexpected any and other lint errors)*
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_688b9e766de0832e9461a047a0e13094