### PR TITLE
Maintain CourseCard skeleton styling

### DIFF
--- a/src/components/ui/skeleton.tsx
+++ b/src/components/ui/skeleton.tsx
@@ -59,7 +59,7 @@ export function CourseCardSkeleton() {
   return (
     <div className="border rounded-lg overflow-hidden">
       <Skeleton className="h-48 w-full" />
-      <div className="p-6 space-y-3">
+      <div className="p-4 space-y-3">
         <Skeleton className="h-6 w-full" />
         <Skeleton className="h-4 w-3/4" />
         <div className="flex justify-between items-center">


### PR DESCRIPTION
## Summary
- keep existing CourseCard component
- adjust padding in `CourseCardSkeleton` to match `CourseCard`

## Testing
- `npm run lint` *(fails: 69 errors, 25 warnings)*
- `npm test` *(fails: missing script)*

------
https://chatgpt.com/codex/tasks/task_e_688b9e7f4364832eafbf13d82f55dd7d