### PR TITLE
Add course pricing fields

### DIFF
--- a/src/integrations/supabase/types.ts
+++ b/src/integrations/supabase/types.ts
@@ -732,6 +732,10 @@ export type Database = {
           instructor_name: string | null
           is_active: boolean | null
           is_featured: boolean | null
+          price_basic: number | null
+          price_premium: number | null
+          content_url: string | null
+          premium_content_url: string | null
           language: string | null
           platform: string | null
           rating: number | null
@@ -755,6 +759,10 @@ export type Database = {
           instructor_name?: string | null
           is_active?: boolean | null
           is_featured?: boolean | null
+          price_basic?: number | null
+          price_premium?: number | null
+          content_url?: string | null
+          premium_content_url?: string | null
           language?: string | null
           platform?: string | null
           rating?: number | null
@@ -778,6 +786,10 @@ export type Database = {
           instructor_name?: string | null
           is_active?: boolean | null
           is_featured?: boolean | null
+          price_basic?: number | null
+          price_premium?: number | null
+          content_url?: string | null
+          premium_content_url?: string | null
           language?: string | null
           platform?: string | null
           rating?: number | null

--- a/supabase/migrations/20250731052000_b80836be-34ea-490d-9499-e4b2dc5405ea.sql
+++ b/supabase/migrations/20250731052000_b80836be-34ea-490d-9499-e4b2dc5405ea.sql
@@ -1,0 +1,5 @@
+-- Add pricing and content fields to courses
+ALTER TABLE public.courses ADD COLUMN IF NOT EXISTS price_basic DECIMAL(10,2);
+ALTER TABLE public.courses ADD COLUMN IF NOT EXISTS price_premium DECIMAL(10,2);
+ALTER TABLE public.courses ADD COLUMN IF NOT EXISTS content_url TEXT;
+ALTER TABLE public.courses ADD COLUMN IF NOT EXISTS premium_content_url TEXT;


### PR DESCRIPTION
## Summary
- add migration for new course pricing and content fields
- update supabase types for `courses`

## Testing
- `npm run lint` *(fails: unexpected any in existing files)*

------
https://chatgpt.com/codex/tasks/task_e_688b9e7a3f38832eac0bab8be5b4ab94