### PR TITLE
Add Public API Explorer tool

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -69,6 +69,7 @@ const RSS = lazy(() => import("./pages/RSS"));
 const Search = lazy(() => import("./pages/Search"));
 const AIAssistantPage = lazy(() => import("./pages/ai"));
 const ThreatMap = lazy(() => import("./pages/ThreatMap"));
+const PublicAPIExplorer = lazy(() => import("./pages/PublicAPIExplorer"));
 
 // Admin pages - separate chunk
 const AdminDashboard = lazy(() => import("./pages/admin/AdminDashboard"));
@@ -192,6 +193,7 @@ function App() {
                           <Route path="/infrastructure" element={<Infrastructure />} />
                           <Route path="/imei-check" element={<IMEICheck />} />
                           <Route path="/tools" element={<Tools />} />
+                          <Route path="/api-explorer" element={<PublicAPIExplorer />} />
                           <Route path="/threat-map" element={<ThreatMap />} />
                           <Route path="/ai" element={<AIAssistantPage />} />
                           <Route path="/search" element={<Search />} />

--- a/src/components/api-explorer/ApiCard.tsx
+++ b/src/components/api-explorer/ApiCard.tsx
@@ -1,0 +1,47 @@
+import React from "react";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+
+export interface ApiEntry {
+  API: string;
+  Description: string;
+  Auth: string;
+  HTTPS: boolean;
+  Cors: string;
+  Category: string;
+  Link: string;
+}
+
+interface ApiCardProps {
+  entry: ApiEntry;
+}
+
+const ApiCard: React.FC<ApiCardProps> = ({ entry }) => {
+  const handleCopy = async () => {
+    await navigator.clipboard.writeText(entry.Link);
+  };
+
+  return (
+    <div className="border rounded-lg p-4 shadow-sm bg-background hover:shadow-md transition">
+      <h3 className="text-lg font-semibold mb-1">
+        <a href={entry.Link} target="_blank" rel="noopener noreferrer" className="hover:underline">
+          {entry.API}
+        </a>
+      </h3>
+      <p className="text-sm text-muted-foreground mb-2">{entry.Description}</p>
+      <div className="flex items-center flex-wrap gap-2 text-xs mb-2">
+        {entry.Auth ? <Badge variant="secondary">Auth: {entry.Auth}</Badge> : <Badge variant="secondary">No Auth</Badge>}
+        {entry.HTTPS && <Badge variant="secondary">HTTPS</Badge>}
+        <Badge variant="outline">{entry.Category}</Badge>
+      </div>
+      <div className="flex gap-2">
+        <Button asChild size="sm">
+          <a href={entry.Link} target="_blank" rel="noopener noreferrer">View Docs</a>
+        </Button>
+        <Button size="sm" variant="secondary" onClick={handleCopy}>Copy Link</Button>
+      </div>
+    </div>
+  );
+};
+
+export default ApiCard;

--- a/src/components/api-explorer/ApiExplorer.tsx
+++ b/src/components/api-explorer/ApiExplorer.tsx
@@ -1,0 +1,69 @@
+import React, { useEffect, useMemo, useState } from "react";
+import SearchBar from "./SearchBar";
+import FilterPanel from "./FilterPanel";
+import ApiList from "./ApiList";
+import apis from "@/data/apis.json";
+import { ApiEntry } from "./ApiCard";
+
+const ApiExplorer: React.FC = () => {
+  const [query, setQuery] = useState("");
+  const [category, setCategory] = useState("");
+  const [auth, setAuth] = useState("");
+  const [httpsOnly, setHttpsOnly] = useState(false);
+  const [featured, setFeatured] = useState<ApiEntry[]>([]);
+
+  const categories = useMemo(
+    () => Array.from(new Set((apis as ApiEntry[]).map((a) => a.Category))).sort(),
+    []
+  );
+
+  useEffect(() => {
+    const shuffled = [...(apis as ApiEntry[])].sort(() => Math.random() - 0.5);
+    setFeatured(shuffled.slice(0, 3));
+  }, []);
+
+  const filtered = useMemo(() => {
+    return (apis as ApiEntry[]).filter((entry) => {
+      if (httpsOnly && !entry.HTTPS) return false;
+      if (category && entry.Category !== category) return false;
+      if (auth) {
+        if (auth === "" && entry.Auth) return false;
+        if (auth && auth.toLowerCase() !== entry.Auth.toLowerCase()) return false;
+      }
+      const search = query.toLowerCase();
+      return (
+        entry.API.toLowerCase().includes(search) ||
+        entry.Description.toLowerCase().includes(search)
+      );
+    });
+  }, [query, category, auth, httpsOnly]);
+
+  return (
+    <div className="space-y-6">
+      <div className="sticky top-0 bg-background z-10 py-4 space-y-4">
+        <SearchBar query={query} onChange={setQuery} />
+        <FilterPanel
+          categories={categories}
+          category={category}
+          setCategory={setCategory}
+          auth={auth}
+          setAuth={setAuth}
+          httpsOnly={httpsOnly}
+          setHttpsOnly={setHttpsOnly}
+        />
+      </div>
+
+      <div>
+        {featured.length > 0 && (
+          <div className="mb-8 space-y-2">
+            <h2 className="text-xl font-semibold">Featured APIs</h2>
+            <ApiList entries={featured} />
+          </div>
+        )}
+        <ApiList entries={filtered} />
+      </div>
+    </div>
+  );
+};
+
+export default ApiExplorer;

--- a/src/components/api-explorer/ApiList.tsx
+++ b/src/components/api-explorer/ApiList.tsx
@@ -1,0 +1,22 @@
+import React from "react";
+import ApiCard, { ApiEntry } from "./ApiCard";
+
+interface ApiListProps {
+  entries: ApiEntry[];
+}
+
+const ApiList: React.FC<ApiListProps> = ({ entries }) => {
+  if (!entries.length) {
+    return <p className="text-center text-muted-foreground">No APIs found.</p>;
+  }
+
+  return (
+    <div className="grid gap-4 md:grid-cols-2 lg:grid-cols-3">
+      {entries.map((entry) => (
+        <ApiCard key={entry.API + entry.Link} entry={entry} />
+      ))}
+    </div>
+  );
+};
+
+export default ApiList;

--- a/src/components/api-explorer/FilterPanel.tsx
+++ b/src/components/api-explorer/FilterPanel.tsx
@@ -1,0 +1,60 @@
+import React from "react";
+
+interface FilterPanelProps {
+  categories: string[];
+  category: string;
+  setCategory: (value: string) => void;
+  auth: string;
+  setAuth: (value: string) => void;
+  httpsOnly: boolean;
+  setHttpsOnly: (value: boolean) => void;
+}
+
+const FilterPanel: React.FC<FilterPanelProps> = ({
+  categories,
+  category,
+  setCategory,
+  auth,
+  setAuth,
+  httpsOnly,
+  setHttpsOnly
+}) => {
+  return (
+    <div className="flex flex-wrap gap-4 items-center">
+      <select
+        value={category}
+        onChange={(e) => setCategory(e.target.value)}
+        className="px-3 py-2 border rounded-md"
+      >
+        <option value="">All Categories</option>
+        {categories.map((cat) => (
+          <option key={cat} value={cat}>
+            {cat}
+          </option>
+        ))}
+      </select>
+
+      <select
+        value={auth}
+        onChange={(e) => setAuth(e.target.value)}
+        className="px-3 py-2 border rounded-md"
+      >
+        <option value="">All Auth</option>
+        <option value="">No Auth</option>
+        <option value="apiKey">API Key</option>
+        <option value="OAuth">OAuth</option>
+      </select>
+
+      <label className="flex items-center space-x-2">
+        <input
+          type="checkbox"
+          checked={httpsOnly}
+          onChange={(e) => setHttpsOnly(e.target.checked)}
+        />
+        <span>HTTPS Only</span>
+      </label>
+    </div>
+  );
+};
+
+export default FilterPanel;

--- a/src/components/api-explorer/SearchBar.tsx
+++ b/src/components/api-explorer/SearchBar.tsx
@@ -1,0 +1,20 @@
+import React from "react";
+
+interface SearchBarProps {
+  query: string;
+  onChange: (value: string) => void;
+}
+
+const SearchBar: React.FC<SearchBarProps> = ({ query, onChange }) => {
+  return (
+    <input
+      type="text"
+      placeholder="Search APIs..."
+      value={query}
+      onChange={(e) => onChange(e.target.value)}
+      className="w-full px-4 py-2 border rounded-md focus:outline-none focus:ring focus:border-primary"
+    />
+  );
+};
+
+export default SearchBar;

--- a/src/data/apis.json
+++ b/src/data/apis.json
@@ -1,0 +1,56 @@
+[
+  {
+    "API": "Cat Facts",
+    "Description": "Daily cat facts",
+    "Auth": "",
+    "HTTPS": true,
+    "Cors": "no",
+    "Category": "Animals",
+    "Link": "https://alexwohlbruck.github.io/cat-facts/"
+  },
+  {
+    "API": "Dog Facts",
+    "Description": "Random dog facts",
+    "Auth": "",
+    "HTTPS": true,
+    "Cors": "no",
+    "Category": "Animals",
+    "Link": "https://dog-api.kinduff.com/api/facts"
+  },
+  {
+    "API": "OpenWeatherMap",
+    "Description": "Weather data and forecast",
+    "Auth": "apiKey",
+    "HTTPS": true,
+    "Cors": "yes",
+    "Category": "Weather",
+    "Link": "https://openweathermap.org/api"
+  },
+  {
+    "API": "NASA",
+    "Description": "NASA data, including imagery",
+    "Auth": "apiKey",
+    "HTTPS": true,
+    "Cors": "yes",
+    "Category": "Science",
+    "Link": "https://api.nasa.gov"
+  },
+  {
+    "API": "Bored",
+    "Description": "Suggestions for random activities",
+    "Auth": "",
+    "HTTPS": true,
+    "Cors": "yes",
+    "Category": "Games",
+    "Link": "https://www.boredapi.com/api/"
+  },
+  {
+    "API": "JSONPlaceholder",
+    "Description": "Fake REST API for testing",
+    "Auth": "",
+    "HTTPS": true,
+    "Cors": "unknown",
+    "Category": "Development",
+    "Link": "https://jsonplaceholder.typicode.com"
+  }
+]

--- a/src/pages/PublicAPIExplorer.tsx
+++ b/src/pages/PublicAPIExplorer.tsx
@@ -1,0 +1,26 @@
+import { Helmet } from "react-helmet-async";
+import Navbar from "@/components/Navbar";
+import Footer from "@/components/Footer";
+import ApiExplorer from "@/components/api-explorer/ApiExplorer";
+
+const PublicAPIExplorer = () => {
+  return (
+    <div className="flex flex-col min-h-screen">
+      <Helmet>
+        <title>Public API Explorer - Zwanski Tech</title>
+        <meta
+          name="description"
+          content="Browse and discover free public APIs."
+        />
+      </Helmet>
+      <Navbar />
+      <main className="flex-grow container mx-auto p-4 space-y-6">
+        <h1 className="text-3xl font-bold mb-4 text-center">Zwanski Public API Explorer</h1>
+        <ApiExplorer />
+      </main>
+      <Footer />
+    </div>
+  );
+};
+
+export default PublicAPIExplorer;

--- a/src/pages/Tools.tsx
+++ b/src/pages/Tools.tsx
@@ -3,6 +3,7 @@ import Navbar from "@/components/Navbar";
 import Footer from "@/components/Footer";
 import IMEIChecker from "@/components/IMEIChecker";
 import GPTAssistant from "@/components/GPTAssistant";
+import ApiExplorer from "@/components/api-explorer/ApiExplorer";
 import { useLanguage } from "@/context/LanguageContext";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import {
@@ -37,6 +38,14 @@ const Tools = () => {
       description: "Get help with tasks using AI-powered tools including chatbot, resume enhancer, blog generator, and code explainer",
       icon: Bot,
       component: <GPTAssistant />,
+      featured: true
+    },
+    {
+      id: "public-api-explorer",
+      title: "Public API Explorer",
+      description: "Search and explore free public APIs",
+      icon: Globe,
+      component: <ApiExplorer />,
       featured: true
     }
   ];

--- a/tsconfig.app.json
+++ b/tsconfig.app.json
@@ -20,7 +20,8 @@
     "noUnusedParameters": false,
     "noImplicitAny": false,
     "noFallthroughCasesInSwitch": false,
-
+    "resolveJsonModule": true,
+    
     "baseUrl": ".",
     "paths": {
       "@/*": ["./src/*"]


### PR DESCRIPTION
## Summary
- add resolveJsonModule to tsconfig so we can import JSON files
- add API explorer components and sample dataset
- create Public API Explorer page and route
- integrate explorer as a featured tool

## Testing
- `npm install --legacy-peer-deps`
- `npm run lint` *(fails: existing repo lint issues)*
- `npx eslint src/components/api-explorer src/pages/PublicAPIExplorer.tsx src/pages/Tools.tsx src/App.tsx`

------
https://chatgpt.com/codex/tasks/task_e_688c1ccdae54832eaef54f5abcbefc54