### PR TITLE
Enhance tool cards and API search input

### DIFF
--- a/src/components/GPTAssistant.tsx
+++ b/src/components/GPTAssistant.tsx
@@ -54,7 +54,7 @@ export default function GPTAssistant() {
   }
 
   return (
-    <Card className="w-full max-w-2xl mx-auto my-8 px-4">
+    <Card className="w-full max-w-4xl mx-auto my-8 px-4">
       <CardHeader>
         <CardTitle>Zwanski AI Assistant</CardTitle>
       </CardHeader>

--- a/src/components/IMEIChecker.tsx
+++ b/src/components/IMEIChecker.tsx
@@ -46,7 +46,7 @@ const IMEIChecker = () => {
   };
 
   return (
-    <Card className="w-full max-w-2xl mx-auto">
+    <Card className="w-full max-w-4xl mx-auto">
       <CardHeader className="text-center">
         <div className="flex items-center justify-center gap-2 mb-2">
           <Smartphone className="h-6 w-6 text-primary" />

--- a/src/components/api-explorer/SearchBar.tsx
+++ b/src/components/api-explorer/SearchBar.tsx
@@ -12,7 +12,7 @@ const SearchBar: React.FC<SearchBarProps> = ({ query, onChange }) => {
       placeholder="Search APIs..."
       value={query}
       onChange={(e) => onChange(e.target.value)}
-      className="w-full px-4 py-2 border rounded-md focus:outline-none focus:ring focus:border-primary"
+      className="w-full px-4 py-2 border border-border rounded-md bg-muted focus:outline-none focus:ring focus:border-primary"
     />
   );
 };


### PR DESCRIPTION
## Summary
- match tool card widths to Public API Explorer
- darken the API Explorer search bar for better visibility

## Testing
- `npm run lint` *(fails: 63 errors, 25 warnings)*

------
https://chatgpt.com/codex/tasks/task_e_688c2304b54c832e94b424cbde7f44a1