### PR TITLE
Fix news ticker position

### DIFF
--- a/index.html
+++ b/index.html
@@ -211,7 +211,7 @@
     <!-- End Axeptio Enhancements -->
   </head>
 
-  <body>
+  <body class="pt-[4.5rem]">
     <!-- Google Tag Manager (noscript) -->
     <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-PM37NL7K"
     height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>

--- a/src/components/NewsTicker.jsx
+++ b/src/components/NewsTicker.jsx
@@ -37,13 +37,13 @@ export default function NewsTicker() {
 
   return (
     <div className="fixed top-0 left-0 w-full z-50">
-      <div className="bg-primary text-primary-foreground overflow-hidden h-7 sm:h-8">
+      <div className="bg-primary text-primary-foreground h-8 sm:h-9">
         <div className="ticker-animation whitespace-nowrap px-4 font-medium">
           🇵🇸 Free Palestine & 🇺🇦 Free Ukraine
         </div>
       </div>
       <div
-        className="bg-muted/50 text-foreground overflow-hidden h-9 sm:h-10 flex items-center"
+        className="bg-muted/50 text-foreground h-10 sm:h-11 flex items-center"
         onMouseEnter={() => setPaused(true)}
         onMouseLeave={() => setPaused(false)}
       >


### PR DESCRIPTION
## Summary
- keep ticker visible at top without clipping
- add body padding so content sits below ticker

## Testing
- `npm run lint` *(fails: 63 errors, 25 warnings)*

------
https://chatgpt.com/codex/tasks/task_e_688c340e184c832eb59670eabc85a917