### PR TITLE
Fix No Auth filter in API explorer

### DIFF
--- a/src/components/api-explorer/ApiExplorer.tsx
+++ b/src/components/api-explorer/ApiExplorer.tsx
@@ -32,9 +32,10 @@ const ApiExplorer: React.FC = () => {
     return apis.filter((entry) => {
       if (httpsOnly && !entry.HTTPS) return false;
       if (category && entry.Category !== category) return false;
-      if (auth) {
-        if (auth === "" && entry.Auth) return false;
-        if (auth && auth.toLowerCase() !== entry.Auth.toLowerCase()) return false;
+      if (auth === "none") {
+        if (entry.Auth) return false;
+      } else if (auth) {
+        if (entry.Auth.toLowerCase() !== auth.toLowerCase()) return false;
       }
       const search = query.toLowerCase();
       return (

--- a/src/components/api-explorer/FilterPanel.tsx
+++ b/src/components/api-explorer/FilterPanel.tsx
@@ -40,7 +40,7 @@ const FilterPanel: React.FC<FilterPanelProps> = ({
         className="px-3 py-2 border rounded-md"
       >
         <option value="">All Auth</option>
-        <option value="">No Auth</option>
+        <option value="none">No Auth</option>
         <option value="apiKey">API Key</option>
         <option value="OAuth">OAuth</option>
       </select>


### PR DESCRIPTION
## Summary
- add distinct `none` value for "No Auth" option
- update filter logic for `none` auth selection

## Testing
- `npm run lint` *(fails: 63 errors, 25 warnings)*
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_688c3b9b3384832e83d9c4e45a328d8c