### PR TITLE
Add Google reCAPTCHA keys

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -3,4 +3,8 @@ SUPABASE_ANON_KEY=
 
 # Cloudflare Turnstile Configuration
 VITE_TURNSTILE_SITE_KEY=your_cloudflare_turnstile_site_key_here
+
+# Google reCAPTCHA v3 Configuration
+RECAPTCHA_SITE_KEY=6LcKP5UrAAAAAPckgYOCbzV1MbvHMe9zCborYWtN
+RECAPTCHA_SECRET_KEY=6LcKP5UrAAAAAPcX_eYQelEPAia9N3zpL7fdrWtG
 VITE_NEWS_API_KEY=your_news_api_key_here

--- a/README.md
+++ b/README.md
@@ -53,6 +53,17 @@ HCAPTCHA_SITE_KEY=your-public-site-key-here
 HCAPTCHA_SECRET_KEY=your-secret-key-here
 ```
 
+Optional variables for **Google reCAPTCHA v3**:
+
+```bash
+RECAPTCHA_SITE_KEY=6LcKP5UrAAAAAPckgYOCbzV1MbvHMe9zCborYWtN
+RECAPTCHA_SECRET_KEY=6LcKP5UrAAAAAPcX_eYQelEPAia9N3zpL7fdrWtG
+```
+
+These keys are registered for `zwanski.org` and enable reCAPTCHA verification across the site.
+
+Add `RECAPTCHA_SECRET_KEY` to your server or Supabase secrets for server-side validation.
+
 If `HCAPTCHA_SITE_KEY` is not set, security verification is skipped and users can sign in or sign up without completing hCaptcha.
 
 Set these in your Supabase project secrets so the `get-hcaptcha-config` and `verify-hcaptcha` edge functions can work properly.


### PR DESCRIPTION
## Summary
- document Google reCAPTCHA v3 setup in README
- provide sample keys in `.env.example`

## Testing
- `npm run lint` *(fails: 63 errors, 25 warnings)*

------
https://chatgpt.com/codex/tasks/task_e_688c50f07bdc832e8cadd0fa6062b19c