### PR TITLE
Mobile-First: Fix responsiveness on ≤480px screens

### DIFF
--- a/src/components/Navbar.tsx
+++ b/src/components/Navbar.tsx
@@ -164,10 +164,10 @@ const Navbar = () => {
             )}
 
             {/* Mobile Menu Button */}
-            <Button 
-              variant="ghost" 
-              size="sm" 
-              className="lg:hidden"
+            <Button
+              variant="ghost"
+              size="sm"
+              className="nav-toggle lg:hidden"
               onClick={() => setIsMenuOpen(!isMenuOpen)}
             >
               {isMenuOpen ? <X className="h-5 w-5" /> : <Menu className="h-5 w-5" />}
@@ -186,7 +186,7 @@ const Navbar = () => {
         )}
 
         {/* Desktop Navigation Bar */}
-        <div className="hidden lg:block border-t border-border/30 py-2">
+        <div className="nav-menu hidden lg:block border-t border-border/30 py-2">
           <div className="flex items-center justify-between">
             {/* Main navigation */}
             <div className="flex items-center space-x-1">
@@ -238,7 +238,7 @@ const Navbar = () => {
 
         {/* Mobile Menu */}
         {isMenuOpen && (
-          <div className="lg:hidden border-t border-border/30 py-4 bg-background/95 backdrop-blur-sm">
+          <div className="nav-menu lg:hidden border-t border-border/30 py-4 bg-background/95 backdrop-blur-sm">
             <div className="space-y-4">
               {/* Mobile auth buttons for non-authenticated users */}
               {!isAuthenticated && (

--- a/src/index.css
+++ b/src/index.css
@@ -7,6 +7,7 @@
 @import './styles/axeptio.css';
 @import './styles/performance.css';
 @import './styles/preloader.css';
+@import './styles/mobile-first.css';
 
 /* Import Tailwind CSS directives */
 @tailwind base;

--- a/src/styles/mobile-first.css
+++ b/src/styles/mobile-first.css
@@ -1,0 +1,47 @@
+/* Mobile-first base styles */
+html {
+  font-size: 16px;
+}
+
+body {
+  line-height: 1.5;
+}
+
+/* Navigation */
+.nav-menu {
+  display: none;
+}
+
+.nav-toggle {
+  display: block;
+}
+
+/* Ensure images and videos don't overflow */
+img,
+video {
+  max-width: 100%;
+  height: auto;
+}
+
+.container {
+  max-width: 100%;
+  padding-left: 1rem;
+  padding-right: 1rem;
+}
+
+@media (min-width: 481px) {
+  .nav-menu {
+    display: flex !important;
+  }
+  .nav-toggle {
+    display: none !important;
+  }
+  .container {
+    padding-left: 2rem;
+    padding-right: 2rem;
+  }
+}
+
+@media (min-width: 769px) {
+  /* desktop enhancements can go here */
+}


### PR DESCRIPTION
## Summary
- add `mobile-first.css` with base mobile styles and breakpoints
- hide/show navigation via `.nav-menu` and `.nav-toggle`
- import the new stylesheet

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_688cf48e1718832eb53e869559588c40