### PR TITLE
Improve responsiveness

### DIFF
--- a/index.html
+++ b/index.html
@@ -45,7 +45,17 @@
     <!-- Critical CSS inline -->
     <style>
       /* Critical above-the-fold CSS for hero section */
-      .hero-container{min-height:100vh;display:flex;align-items:center;justify-content:center;padding:1rem;position:relative;overflow:hidden}.hero-content{max-width:1200px;width:100%;display:grid;grid-template-columns:1fr 1fr;gap:3rem;align-items:center}.hero-text{z-index:10}.hero-title{font-size:3.75rem;font-weight:700;line-height:1.1;margin-bottom:1.5rem}.hero-subtitle{font-size:1.25rem;line-height:1.6;margin-bottom:2rem;opacity:0.9}.hero-image-container{position:relative;height:500px;width:600px;border-radius:1rem;overflow:hidden}.hero-buttons{display:flex;gap:1rem;flex-wrap:wrap}.hero-button{padding:0.75rem 2rem;border-radius:0.5rem;font-weight:500;text-decoration:none;display:inline-flex;align-items:center;gap:0.5rem;transition:all 0.2s ease-in-out}:root{--background:0 0% 100%;--foreground:222.2 84% 4.9%;--primary:221 83% 53%;--primary-foreground:210 40% 98%;--muted:210 40% 96%;--muted-foreground:215.4 16.3% 46.9%;--border:214.3 31.8% 91.4%}[data-theme="dark"]{--background:222.2 84% 4.9%;--foreground:210 40% 98%;--primary:221 83% 53%;--primary-foreground:222.2 84% 4.9%;--muted:217.2 32.6% 17.5%;--muted-foreground:215 20.2% 65.1%;--border:217.2 32.6% 17.5%}@media (max-width:768px){.hero-content{grid-template-columns:1fr;gap:2rem;text-align:center}.hero-title{font-size:2.5rem}.hero-image-container{height:300px;width:100%;max-width:400px;margin:0 auto}}
+      .hero-container{min-height:100vh;display:flex;align-items:center;justify-content:center;padding:1rem;position:relative;overflow:hidden}
+      .hero-content{max-width:1200px;width:100%;display:grid;grid-template-columns:1fr 1fr;gap:3rem;align-items:center}
+      .hero-text{z-index:10}
+      .hero-title{font-size:clamp(2.5rem,5vw,4.5rem);font-weight:700;line-height:1.1;margin-bottom:1.5rem}
+      .hero-subtitle{font-size:clamp(1rem,2.5vw,1.5rem);line-height:1.6;margin-bottom:2rem;opacity:0.9}
+      .hero-image-container{position:relative;height:clamp(300px,50vh,600px);width:clamp(250px,50vw,600px);border-radius:1rem;overflow:hidden}
+      .hero-buttons{display:flex;gap:1rem;flex-wrap:wrap}
+      .hero-button{padding:0.75rem 2rem;border-radius:0.5rem;font-weight:500;text-decoration:none;display:inline-flex;align-items:center;gap:0.5rem;transition:all 0.2s ease-in-out}
+      :root{--background:0 0% 100%;--foreground:222.2 84% 4.9%;--primary:221 83% 53%;--primary-foreground:210 40% 98%;--muted:210 40% 96%;--muted-foreground:215.4 16.3% 46.9%;--border:214.3 31.8% 91.4%}
+      [data-theme="dark"]{--background:222.2 84% 4.9%;--foreground:210 40% 98%;--primary:221 83% 53%;--primary-foreground:222.2 84% 4.9%;--muted:217.2 32.6% 17.5%;--muted-foreground:215 20.2% 65.1%;--border:217.2 32.6% 17.5%}
+      @media (max-width:768px){.hero-content{grid-template-columns:1fr;gap:2rem;text-align:center}.hero-title{font-size:clamp(2rem,8vw,2.5rem)}.hero-image-container{height:300px;width:100%;max-width:400px;margin:0 auto}}
     </style>
     
     <!-- Axeptio Cookie Consent -->

--- a/src/components/ui/drawer.tsx
+++ b/src/components/ui/drawer.tsx
@@ -46,7 +46,7 @@ const DrawerContent = React.forwardRef<
       )}
       {...props}
     >
-      <div className="mx-auto mt-4 h-2 w-[100px] rounded-full bg-muted" />
+      <div className="mx-auto mt-4 h-2 w-24 rounded-full bg-muted" />
       {children}
     </DrawerPrimitive.Content>
   </DrawerPortal>

--- a/src/components/ui/toast.tsx
+++ b/src/components/ui/toast.tsx
@@ -14,7 +14,7 @@ const ToastViewport = React.forwardRef<
   <ToastPrimitives.Viewport
     ref={ref}
     className={cn(
-      "fixed top-0 z-[100] flex max-h-screen w-full flex-col-reverse p-4 sm:bottom-0 sm:right-0 sm:top-auto sm:flex-col md:max-w-[420px]",
+      "fixed top-0 z-[100] flex max-h-screen w-full flex-col-reverse p-4 sm:bottom-0 sm:right-0 sm:top-auto sm:flex-col md:max-w-md",
       className
     )}
     {...props}

--- a/src/pages/admin/AdminUsers.tsx
+++ b/src/pages/admin/AdminUsers.tsx
@@ -159,7 +159,7 @@ export default function AdminUsers() {
             />
           </div>
           <Select value={filterType} onValueChange={setFilterType}>
-            <SelectTrigger className="w-[180px]">
+            <SelectTrigger className="w-44">
               <SelectValue placeholder="Filter by type" />
             </SelectTrigger>
             <SelectContent>
@@ -213,7 +213,7 @@ export default function AdminUsers() {
                         }
                       }}
                     >
-                      <SelectTrigger className="w-[120px]">
+                      <SelectTrigger className="w-32">
                         <SelectValue />
                       </SelectTrigger>
                       <SelectContent>

--- a/src/styles/axeptio.css
+++ b/src/styles/axeptio.css
@@ -6,7 +6,7 @@
 }
 
 .axeptio-container {
-  @apply max-w-6xl mx-auto px-6;
+  @apply max-w-screen-2xl mx-auto px-6;
 }
 
 /* Typography system */

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -10,15 +10,21 @@ export default {
                 "./src/**/*.{ts,tsx,js,jsx}",
         ],
 	prefix: "",
-	theme: {
-		container: {
-			center: true,
-			padding: '2rem',
-			screens: {
-				'2xl': '1400px'
-			}
-		},
-		extend: {
+        theme: {
+                container: {
+                        center: true,
+                        padding: '2rem',
+                        screens: {
+                                '2xl': '1400px',
+                                '3xl': '1600px',
+                                '4xl': '1800px'
+                        }
+                },
+                screens: {
+                        '3xl': '1600px',
+                        '4xl': '1800px'
+                },
+                extend: {
 			colors: {
 				border: 'hsl(var(--border))',
 				input: 'hsl(var(--input))',


### PR DESCRIPTION
## Summary
- tweak hero section for fluid sizing
- widen Axeptio container
- add extra Tailwind breakpoints
- fix px-based widths in Admin users, drawer and toast components

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_688cf75b1ab8832ea883b4a1eb8db85e