### PR TITLE
Fix chat container height

### DIFF
--- a/src/pages/Chat.tsx
+++ b/src/pages/Chat.tsx
@@ -208,7 +208,7 @@ const Chat = () => {
           {!isAuthenticated ? (
             <LoginForm />
           ) : (
-            <div className="flex flex-col h-[600px]">
+            <div className="flex flex-col min-h-[60vh]">
               <div className="flex-1 overflow-y-auto p-4 space-y-4">
                 {connectionError && (
                   <div className="bg-red-50 border border-red-200 rounded-lg p-4 mb-4">


### PR DESCRIPTION
## Summary
- make Chat container height responsive using `min-h-[60vh]`

## Testing
- `npm run lint` *(fails: 63 errors, 25 warnings)*
- `npm test` *(fails: missing script)*

------
https://chatgpt.com/codex/tasks/task_e_688cf955696c832e950bb2fcf4913646