### PR TITLE
Refactor footer with HeroUI layout components

### DIFF
--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -4,6 +4,7 @@ import { useLanguage } from "@/context/LanguageContext";
 import { Helmet } from "react-helmet-async";
 import { Link } from "react-router-dom";
 import DMCABadge from "@/components/DMCABadge";
+import { Container, Spacer } from "@/components/heroui";
 
 export default function Footer() {
   const { t } = useLanguage();
@@ -26,8 +27,8 @@ export default function Footer() {
       </Helmet>
       
       <footer className="py-12 bg-secondary/30 border-t border-border">
-        <div className="container mx-auto px-4">
-          <div className="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-5 lg:grid-cols-7 gap-8 mb-8">
+        <Container className="px-4">
+          <div className="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-5 lg:grid-cols-7 gap-8">
             {/* Company Info */}
             <div className="sm:col-span-2 md:col-span-3 lg:col-span-2">
               <Link to="/" className="text-xl font-bold text-gradient">
@@ -254,7 +255,7 @@ export default function Footer() {
               </ul>
             </div>
           </div>
-
+          <Spacer y={8} />
           <div className="pt-8 border-t border-border">
             <div className="flex flex-col md:flex-row justify-between items-center">
               <p className="text-sm text-muted-foreground">
@@ -283,7 +284,7 @@ export default function Footer() {
               </div>
             </div>
           </div>
-        </div>
+        </Container>
       </footer>
     </>
   );

--- a/src/components/heroui/Container.tsx
+++ b/src/components/heroui/Container.tsx
@@ -1,0 +1,8 @@
+import React from "react";
+import { cn } from "@/lib/utils";
+
+export interface ContainerProps extends React.HTMLAttributes<HTMLDivElement> {}
+
+export function Container({ className, ...props }: ContainerProps) {
+  return <div className={cn("mx-auto container", className)} {...props} />;
+}

--- a/src/components/heroui/Spacer.tsx
+++ b/src/components/heroui/Spacer.tsx
@@ -1,0 +1,7 @@
+import SpacerPrimitive, { type SpacerProps as SpacerPrimitiveProps } from "@heroui/spacer";
+
+export type SpacerProps = SpacerPrimitiveProps;
+
+export function Spacer(props: SpacerProps) {
+  return <SpacerPrimitive {...props} />;
+}

--- a/src/components/heroui/index.ts
+++ b/src/components/heroui/index.ts
@@ -1,3 +1,5 @@
 export * from './Button';
 export * from './Card';
 export * from './Form';
+export * from './Container';
+export * from './Spacer';


### PR DESCRIPTION
## Summary
- switch footer layout to use `Container` wrapper and `Spacer`
- export new layout components from HeroUI index
- implement new `Container` and `Spacer` wrappers

## Testing
- `npm run lint`
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_688d4787aa50832eae4bc1baf78269e7