### PR TITLE
Add preloader safety timeout

### DIFF
--- a/src/components/Preloader.tsx
+++ b/src/components/Preloader.tsx
@@ -38,6 +38,13 @@ const Preloader: React.FC<PreloaderProps> = ({ onComplete }) => {
     }, 2500); // Total preloader duration
     timeouts.push(completeTimeout);
 
+    // Safety timeout in case animations fail
+    const safetyTimeout = setTimeout(() => {
+      setIsVisible(false);
+      onComplete();
+    }, 5000);
+    timeouts.push(safetyTimeout);
+
     return () => {
       timeouts.forEach(clearTimeout);
     };


### PR DESCRIPTION
## Summary
- avoid getting stuck on white screen by adding a fallback timeout to the Preloader

## Testing
- `npm run lint` *(fails: Unexpected any rules)*

------
https://chatgpt.com/codex/tasks/task_e_688d51ee1870832e8770f0c7929d173a