### PR TITLE
Apply fetch priority hints

### DIFF
--- a/index.html
+++ b/index.html
@@ -41,6 +41,8 @@
     <!-- Optimized critical font preload -->
     <link rel="preload" href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700&display=swap" as="style" onload="this.onload=null;this.rel='stylesheet'">
     <noscript><link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700&display=swap"></noscript>
+
+    <link rel="stylesheet" href="/src/index.css" fetchpriority="high">
     
     <!-- Critical CSS inline -->
     <style>
@@ -66,7 +68,9 @@
      
     (function(d, s) {
       var t = d.getElementsByTagName(s)[0], e = d.createElement(s);
-      e.async = true; e.src = "//static.axept.io/sdk.js";
+      e.async = true;
+      e.src = "//static.axept.io/sdk.js";
+      e.fetchPriority = "low";
       t.parentNode.insertBefore(e, t);
     })(document, "script");
     </script>
@@ -111,7 +115,7 @@
     <!-- End Schema.org -->
     
     <!-- hCaptcha -->
-    <script src="https://js.hcaptcha.com/1/api.js" async defer></script>
+    <script src="https://js.hcaptcha.com/1/api.js" async defer fetchpriority="low"></script>
     
 
     <style>
@@ -236,6 +240,7 @@
         var gtag = document.createElement('script');
         gtag.async = true;
         gtag.src = 'https://www.googletagmanager.com/gtag/js?id=G-JCY70KNM0Y';
+        gtag.fetchPriority = 'low';
         gtag.onload = function() {
           window.dataLayer = window.dataLayer || [];
           function gtagFn(){dataLayer.push(arguments);}
@@ -250,13 +255,13 @@
           (function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
           new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
           j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
-          'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
+          'https://www.googletagmanager.com/gtm.js?id='+i+dl;j.fetchPriority='low';f.parentNode.insertBefore(j,f);
           })(window,document,'script','dataLayer','GTM-PM37NL7K');
         }, 1000);
       }
     </script>
     
     <!-- IMPORTANT: DO NOT REMOVE THIS SCRIPT TAG OR THIS VERY COMMENT! -->
-    <script src="https://cdn.gpteng.co/gptengineer.js" type="module"></script>
+    <script src="https://cdn.gpteng.co/gptengineer.js" type="module" fetchpriority="low"></script>
   </body>
 </html>

--- a/src/components/DMCABadge.tsx
+++ b/src/components/DMCABadge.tsx
@@ -18,6 +18,7 @@ export default function DMCABadge({
     script.src = 'https://images.dmca.com/Badges/DMCABadgeHelper.min.js';
     script.async = true;
     script.defer = true;
+    (script as HTMLScriptElement).fetchPriority = 'low';
     document.head.appendChild(script);
 
     return () => {

--- a/src/components/HCaptchaWidget.tsx
+++ b/src/components/HCaptchaWidget.tsx
@@ -62,6 +62,7 @@ const HCaptchaWidget: React.FC<HCaptchaWidgetProps> = ({
         script.src = 'https://js.hcaptcha.com/1/api.js?render=explicit';
         script.async = true;
         script.defer = true;
+        (script as HTMLScriptElement).fetchPriority = 'low';
         
         script.onload = () => {
           console.log('✅ hCaptcha script loaded successfully');


### PR DESCRIPTION
## Summary
- add high priority hint for main stylesheet
- mark hCaptcha script as low priority
- load Axeptio, Analytics and GTM scripts with low priority
- defer DMCA badge and hCaptcha widget scripts with low priority

## Testing
- `npm run lint` *(fails: unexpected any and other lint errors)*

------
https://chatgpt.com/codex/tasks/task_e_688d59e9d1ac832e97d3e73e3da19af7