### PR TITLE
Add fetchpriority hints to key assets

### DIFF
--- a/index.html
+++ b/index.html
@@ -39,7 +39,7 @@
     <meta http-equiv="Referrer-Policy" content="strict-origin-when-cross-origin">
     <link rel="alternate" type="application/atom+xml" title="Zwanski Tech Website Feed" href="https://zwanski2019.github.io/ZWANSKI-TECH/atom.xml" />
     <!-- Optimized critical font preload -->
-    <link rel="preload" href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700&display=swap" as="style" onload="this.onload=null;this.rel='stylesheet'">
+    <link rel="preload" href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700&display=swap" as="style" onload="this.onload=null;this.rel='stylesheet'" fetchpriority="high">
     <noscript><link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700&display=swap"></noscript>
     
     <!-- Critical CSS inline -->
@@ -218,7 +218,7 @@
     <!-- End Google Tag Manager (noscript) -->
     
     <div id="root"></div>
-    <script type="module" src="/src/main.tsx"></script>
+    <script type="module" src="/src/main.tsx" fetchpriority="high"></script>
     
     <!-- Load analytics after main app with reduced priority -->
     <script>

--- a/src/components/DMCABadge.tsx
+++ b/src/components/DMCABadge.tsx
@@ -50,11 +50,12 @@ export default function DMCABadge({
         rel="noopener noreferrer"
         aria-label="DMCA Protection Status - Content is protected by DMCA.com"
       >
-        <img 
+        <img
           src={getBadgeImage()}
-          alt="DMCA.com Protection Status" 
+          alt="DMCA.com Protection Status"
           className="max-w-none"
           loading="lazy"
+          fetchPriority="low"
         />
       </a>
       {showText && (

--- a/src/components/academy/CourseCard.tsx
+++ b/src/components/academy/CourseCard.tsx
@@ -152,10 +152,12 @@ const CourseCard = ({ course, isEnrolled, viewMode, subscriptionStatus }: Course
       <Card className="flex flex-row p-4 hover:shadow-lg transition-shadow">
         <div className="w-32 h-20 bg-muted rounded-lg flex-shrink-0 mr-4 flex items-center justify-center">
           {course.thumbnail_url ? (
-            <img 
-              src={course.thumbnail_url} 
+            <img
+              src={course.thumbnail_url}
               alt={course.title}
               className="w-full h-full object-cover rounded-lg"
+              loading="lazy"
+              fetchPriority="low"
             />
           ) : (
             <BookOpen className="h-8 w-8 text-muted-foreground" />
@@ -237,10 +239,12 @@ const CourseCard = ({ course, isEnrolled, viewMode, subscriptionStatus }: Course
       <CardHeader className="p-0 relative">
         <div className="aspect-video bg-muted rounded-t-lg overflow-hidden">
           {course.thumbnail_url ? (
-            <img 
-              src={course.thumbnail_url} 
+            <img
+              src={course.thumbnail_url}
               alt={course.title}
               className="w-full h-full object-cover group-hover:scale-105 transition-transform duration-300"
+              loading="lazy"
+              fetchPriority="low"
             />
           ) : (
             <div className="w-full h-full flex items-center justify-center">

--- a/src/components/academy/UserDashboard.tsx
+++ b/src/components/academy/UserDashboard.tsx
@@ -143,10 +143,12 @@ const UserDashboard = () => {
               <div key={enrollment.id} className="flex items-center space-x-4">
                 <div className="w-16 h-12 bg-muted rounded flex-shrink-0">
                   {enrollment.courses?.thumbnail_url ? (
-                    <img 
-                      src={enrollment.courses.thumbnail_url} 
+                    <img
+                      src={enrollment.courses.thumbnail_url}
                       alt={enrollment.courses.title}
                       className="w-full h-full object-cover rounded"
+                      loading="lazy"
+                      fetchPriority="low"
                     />
                   ) : (
                     <div className="w-full h-full flex items-center justify-center">
@@ -188,10 +190,12 @@ const UserDashboard = () => {
                 <div key={bookmark.id} className="flex items-center space-x-3 p-3 rounded-lg border">
                   <div className="w-12 h-8 bg-muted rounded flex-shrink-0">
                     {bookmark.courses?.thumbnail_url ? (
-                      <img 
-                        src={bookmark.courses.thumbnail_url} 
+                      <img
+                        src={bookmark.courses.thumbnail_url}
                         alt={bookmark.courses.title}
                         className="w-full h-full object-cover rounded"
+                        loading="lazy"
+                        fetchPriority="low"
                       />
                     ) : (
                       <div className="w-full h-full flex items-center justify-center">

--- a/src/components/blog/BlogCard.tsx
+++ b/src/components/blog/BlogCard.tsx
@@ -28,6 +28,7 @@ export function BlogCard({ post }: BlogCardProps) {
             alt={post.title}
             className="w-full h-full object-cover transition-transform duration-300 hover:scale-105"
             loading="lazy"
+            fetchPriority="low"
           />
         </div>
       )}

--- a/src/components/dynamic/DynamicProjects.tsx
+++ b/src/components/dynamic/DynamicProjects.tsx
@@ -78,10 +78,12 @@ const DynamicProjects = () => {
             <Card key={project.id} className="overflow-hidden group hover:shadow-lg transition-all duration-300 animate-on-scroll">
               {project.featured_image_url && (
                 <div className="relative overflow-hidden">
-                  <img 
-                    src={project.featured_image_url} 
+                  <img
+                    src={project.featured_image_url}
                     alt={project.title}
                     className="w-full h-48 object-cover group-hover:scale-105 transition-transform duration-300"
+                    loading="lazy"
+                    fetchPriority="low"
                   />
                   {project.featured && (
                     <Badge className="absolute top-3 right-3 bg-yellow-500 text-black">

--- a/src/components/tutoring/CourseDetails.tsx
+++ b/src/components/tutoring/CourseDetails.tsx
@@ -43,10 +43,11 @@ const CourseDetails = () => {
         <div className="grid grid-cols-1 lg:grid-cols-3 gap-8">
           <div className="lg:col-span-2">
             <div className="relative mb-6">
-              <img 
-                src={course.image} 
+              <img
+                src={course.image}
                 alt={course.imageAlt}
                 className="w-full h-64 object-cover rounded-lg"
+                fetchPriority="high"
               />
               <Button 
                 size="lg"

--- a/src/components/tutoring/TutoringPlatform.tsx
+++ b/src/components/tutoring/TutoringPlatform.tsx
@@ -198,10 +198,12 @@ const TutoringPlatform = () => {
             {featuredCourses.map((course) => (
               <Card key={course.id} className="group hover:shadow-2xl transition-all duration-300 transform hover:-translate-y-2 overflow-hidden border-0 shadow-lg">
                 <div className="relative">
-                  <img 
-                    src={course.image} 
+                  <img
+                    src={course.image}
                     alt={course.title}
                     className="w-full h-48 object-cover group-hover:scale-105 transition-transform duration-300"
+                    loading="lazy"
+                    fetchPriority="low"
                   />
                   <div className="absolute top-4 left-4 bg-red-500 text-white px-3 py-1 rounded-full text-sm font-bold">
                     BESTSELLER
@@ -253,10 +255,12 @@ const TutoringPlatform = () => {
             {filteredCourses.map((course) => (
               <Card key={course.id} className="group hover:shadow-xl transition-all duration-300 transform hover:-translate-y-1 overflow-hidden">
                 <div className="relative">
-                  <img 
-                    src={course.image} 
+                  <img
+                    src={course.image}
                     alt={course.title}
                     className="w-full h-40 object-cover group-hover:scale-105 transition-transform duration-300"
+                    loading="lazy"
+                    fetchPriority="low"
                   />
                   {course.bestseller && (
                     <div className="absolute top-2 left-2 bg-red-500 text-white px-2 py-1 rounded text-xs font-bold">

--- a/src/components/youtube/VideoCard.tsx
+++ b/src/components/youtube/VideoCard.tsx
@@ -15,11 +15,12 @@ export default function VideoCard({ video, onVideoClick }: VideoCardProps) {
       onClick={() => onVideoClick(video)}
     >
       <div className="aspect-video relative overflow-hidden">
-        <img 
-          src={video.thumbnail} 
-          alt={video.title} 
+        <img
+          src={video.thumbnail}
+          alt={video.title}
           className="w-full h-full object-cover transition-transform duration-500 group-hover:scale-105"
           loading="lazy"
+          fetchPriority="low"
         />
         
         <div className="absolute inset-0 bg-black/30 flex items-center justify-center opacity-0 group-hover:opacity-100 transition-opacity">


### PR DESCRIPTION
## Summary
- add `fetchpriority` to critical font preload and main script
- set low priority on various non-critical images
- mark course detail hero image as high priority

## Testing
- `npm run lint` *(fails: Unexpected any types)*

------
https://chatgpt.com/codex/tasks/task_e_688d5f0c1ddc832ea48df5a222c07d00