### PR TITLE
feat: add gravatar edge function

### DIFF
--- a/src/hooks/useGravatar.ts
+++ b/src/hooks/useGravatar.ts
@@ -1,0 +1,38 @@
+import { useState } from 'react';
+
+interface GravatarProfile {
+  entry?: unknown[];
+  [key: string]: unknown;
+}
+
+export const useGravatar = () => {
+  const [profile, setProfile] = useState<GravatarProfile | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [isLoading, setIsLoading] = useState(false);
+
+  const fetchProfile = async (email: string) => {
+    setIsLoading(true);
+    setError(null);
+
+    try {
+      const response = await fetch(`https://ceihcnfngpmrtqunhaey.functions.supabase.co/gravatar?email=${encodeURIComponent(email)}`);
+      if (!response.ok) {
+        throw new Error('Failed to fetch Gravatar profile');
+      }
+      const data = await response.json();
+      setProfile(data);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'An unexpected error occurred');
+    } finally {
+      setIsLoading(false);
+    }
+  };
+
+  const reset = () => {
+    setProfile(null);
+    setError(null);
+    setIsLoading(false);
+  };
+
+  return { profile, error, isLoading, fetchProfile, reset };
+};

--- a/supabase/functions/gravatar/index.ts
+++ b/supabase/functions/gravatar/index.ts
@@ -1,0 +1,72 @@
+import { serve } from "https://deno.land/std@0.168.0/http/server.ts";
+import { createHash } from "https://deno.land/std@0.168.0/hash/md5.ts";
+
+const corsHeaders = {
+  'Access-Control-Allow-Origin': '*',
+  'Access-Control-Allow-Headers': 'authorization, x-client-info, apikey, content-type',
+};
+
+serve(async (req) => {
+  if (req.method === 'OPTIONS') {
+    return new Response(null, { headers: corsHeaders });
+  }
+
+  try {
+    const url = new URL(req.url);
+    const email = url.searchParams.get('email');
+
+    if (!email) {
+      return new Response(
+        JSON.stringify({ error: 'Email is required' }),
+        {
+          status: 400,
+          headers: { ...corsHeaders, 'Content-Type': 'application/json' }
+        }
+      );
+    }
+
+    const apiKey = Deno.env.get('GRAVATAR_API_KEY');
+    if (!apiKey) {
+      console.error('GRAVATAR_API_KEY not found in environment variables');
+      return new Response(
+        JSON.stringify({ error: 'Service configuration error' }),
+        {
+          status: 500,
+          headers: { ...corsHeaders, 'Content-Type': 'application/json' }
+        }
+      );
+    }
+
+    const hash = createHash('md5').update(email.trim().toLowerCase()).toString();
+
+    const response = await fetch(`https://www.gravatar.com/${hash}.json?apikey=${apiKey}`);
+    if (!response.ok) {
+      console.error('Gravatar API error:', response.status, response.statusText);
+      return new Response(
+        JSON.stringify({ error: 'Gravatar service is currently unavailable' }),
+        {
+          status: 502,
+          headers: { ...corsHeaders, 'Content-Type': 'application/json' }
+        }
+      );
+    }
+
+    const profile = await response.json();
+
+    return new Response(
+      JSON.stringify(profile),
+      {
+        headers: { ...corsHeaders, 'Content-Type': 'application/json' }
+      }
+    );
+  } catch (error) {
+    console.error('Error in gravatar function:', error);
+    return new Response(
+      JSON.stringify({ error: 'Internal server error' }),
+      {
+        status: 500,
+        headers: { ...corsHeaders, 'Content-Type': 'application/json' }
+      }
+    );
+  }
+});


### PR DESCRIPTION
## Summary
- add gravatar edge function to fetch profile data
- expose frontend hook to call deployed gravatar function

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm install --legacy-peer-deps`
- `npm run lint` *(fails: 88 problems)*
- `supabase secrets set GRAVATAR_API_KEY=YOUR_KEY` *(fails: command not found)*
- `supabase functions deploy gravatar` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_688d79753810832eb73ec7a3be8366fc