### PR TITLE
feat: add gravatar link to navbar

### DIFF
--- a/src/components/Navbar.tsx
+++ b/src/components/Navbar.tsx
@@ -2,7 +2,7 @@ import React, { useState, useEffect } from "react";
 import { useNavigate, useLocation } from "react-router-dom";
 import { useAuth } from "@/context/AuthContext";
 import { Button } from "@/components/ui/button";
-import { Menu, X, Home, Wrench, Shield, GraduationCap, Briefcase, Settings2, FileText, MessageSquare, Bot, Activity, Search } from "lucide-react";
+import { Menu, X, Home, Wrench, Shield, GraduationCap, Briefcase, Settings2, FileText, MessageSquare, Bot, Activity, Search, User } from "lucide-react";
 import ZwanskiLogo from "./ZwanskiLogo";
 import { ThemeToggle } from "./ThemeToggle";
 import { LanguageSelector } from "./LanguageSelector";
@@ -92,6 +92,7 @@ const Navbar = () => {
     { label: "Blog", path: "/blog", icon: FileText },
     { label: "Chat", path: "/chat", icon: MessageSquare },
     { label: "AI", path: "/ai", icon: Bot },
+    { label: "Gravatar", path: "/gravatar", icon: User },
     { label: "Threat Map", path: "/threat-map", icon: Activity }
   ];
 


### PR DESCRIPTION
## Summary
- add Gravatar link to main navigation

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: 88 problems (63 errors, 25 warnings))*

------
https://chatgpt.com/codex/tasks/task_e_688d797f455c832e826f4513393d4ed4