### PR TITLE
feat: make supabase function url configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,22 @@ verify_jwt = false
 verify_jwt = false
 ```
 
+#### Supabase Function URL
+
+Some features rely on a Supabase Edge Function. The front-end reads the
+function URL from an environment variable or a `window` configuration.
+
+- **Local development**: add `VITE_GRAVATAR_API_URL` to your `.env.local` file.
+- **Hosted platforms (Vercel, Netlify, etc.)**: define `VITE_GRAVATAR_API_URL`
+  in the platform's environment variable settings.
+- **Static deployments**: inject the value at runtime in `index.html`:
+
+  ```html
+  <script>
+    window.GRAVATAR_API_URL = "wss://your-project.supabase.co/functions/v1/websocket-chat";
+  </script>
+  ```
+
 ## 🔐 Security Features
 
 ✅ **Row Level Security (RLS)** - All tables have proper RLS policies  

--- a/src/hooks/useWebSocket.ts
+++ b/src/hooks/useWebSocket.ts
@@ -1,6 +1,17 @@
 
 import { useState, useEffect, useRef, useCallback } from 'react'
 
+declare global {
+  interface Window {
+    GRAVATAR_API_URL?: string
+  }
+}
+
+const SUPABASE_FUNCTION_URL =
+  window.GRAVATAR_API_URL ||
+  import.meta.env.VITE_GRAVATAR_API_URL ||
+  'wss://ceihcnfngpmrtqunhaey.supabase.co/functions/v1/websocket-chat'
+
 interface ChatMessage {
   id: string
   username: string
@@ -38,7 +49,7 @@ export const useWebSocket = ({ username, avatar }: UseWebSocketProps) => {
     
     try {
       // Use the correct WebSocket URL
-      const ws = new WebSocket('wss://ceihcnfngpmrtqunhaey.supabase.co/functions/v1/websocket-chat')
+      const ws = new WebSocket(SUPABASE_FUNCTION_URL)
       wsRef.current = ws
 
       ws.onopen = () => {


### PR DESCRIPTION
## Summary
- allow WebSocket edge function URL to be configured via `window.GRAVATAR_API_URL` or env var `VITE_GRAVATAR_API_URL`
- document how to set the function URL for local, hosted, and static deployments

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: 88 problems, 63 errors)*

------
https://chatgpt.com/codex/tasks/task_e_688d7980673c832e954735428287cef7