### PR TITLE
feat: secure profile update edge function

### DIFF
--- a/AUTHENTICATION_SETUP.md
+++ b/AUTHENTICATION_SETUP.md
@@ -173,3 +173,12 @@ If you encounter any issues:
 
 **Last Updated**: January 2025
 **Version**: 1.0.0
+## 🔐 Profile Update Auth Flow
+
+To write profile information, clients must provide a valid Supabase access token.
+
+1. Sign in using Supabase Auth to obtain an access token.
+2. Send a request to the `update-profile` Edge Function with the header `Authorization: Bearer <access_token>` and the desired profile fields in the JSON body.
+3. The function verifies the token and updates the signed-in user's row in the `profiles` table.
+4. Requests without a valid token receive a `401 Unauthorized` response and no data is written.
+

--- a/supabase/config.toml
+++ b/supabase/config.toml
@@ -3,3 +3,6 @@ project_id = "ceihcnfngpmrtqunhaey"
 
 [functions.websocket-chat]
 verify_jwt = false
+
+[functions.update-profile]
+verify_jwt = true

--- a/supabase/functions/update-profile/index.ts
+++ b/supabase/functions/update-profile/index.ts
@@ -1,0 +1,67 @@
+import { serve } from "https://deno.land/std@0.168.0/http/server.ts";
+import { createClient } from "https://esm.sh/@supabase/supabase-js@2";
+
+const corsHeaders = {
+  "Access-Control-Allow-Origin": "*",
+  "Access-Control-Allow-Headers": "authorization, x-client-info, apikey, content-type",
+};
+
+serve(async (req) => {
+  // Handle CORS preflight requests
+  if (req.method === "OPTIONS") {
+    return new Response(null, { headers: corsHeaders });
+  }
+
+  const authHeader = req.headers.get("Authorization");
+  if (!authHeader) {
+    return new Response(JSON.stringify({ error: "Unauthorized" }), {
+      status: 401,
+      headers: { ...corsHeaders, "Content-Type": "application/json" },
+    });
+  }
+
+  const token = authHeader.replace("Bearer ", "");
+
+  const supabaseUrl = Deno.env.get("SUPABASE_URL")!;
+  const serviceKey = Deno.env.get("SUPABASE_SERVICE_ROLE_KEY")!;
+  const supabase = createClient(supabaseUrl, serviceKey);
+
+  const {
+    data: { user },
+    error: userError,
+  } = await supabase.auth.getUser(token);
+
+  if (userError || !user) {
+    return new Response(JSON.stringify({ error: "Unauthorized" }), {
+      status: 401,
+      headers: { ...corsHeaders, "Content-Type": "application/json" },
+    });
+  }
+
+  try {
+    const updates = await req.json();
+    const { data, error } = await supabase
+      .from("profiles")
+      .update(updates)
+      .eq("id", user.id)
+      .select();
+
+    if (error) {
+      console.error("Error updating profile:", error);
+      return new Response(JSON.stringify({ error: "Profile update failed" }), {
+        status: 500,
+        headers: { ...corsHeaders, "Content-Type": "application/json" },
+      });
+    }
+
+    return new Response(JSON.stringify({ success: true, data }), {
+      headers: { ...corsHeaders, "Content-Type": "application/json" },
+    });
+  } catch (err) {
+    console.error("Error processing request:", err);
+    return new Response(JSON.stringify({ error: "Invalid request" }), {
+      status: 400,
+      headers: { ...corsHeaders, "Content-Type": "application/json" },
+    });
+  }
+});


### PR DESCRIPTION
## Summary
- add `update-profile` Edge Function that requires a valid Supabase auth token
- enable JWT verification for the new function
- document the profile update auth flow for clients

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: 63 errors, 25 warnings)*

------
https://chatgpt.com/codex/tasks/task_e_688d798b03b8832e8ae2d1e28fa22fe2