### PR TITLE
Localize navigation labels

### DIFF
--- a/src/components/navbar/DesktopNavigation.tsx
+++ b/src/components/navbar/DesktopNavigation.tsx
@@ -1,31 +1,49 @@
 import React from "react";
 import { Link, useLocation } from "react-router-dom";
 import { Button } from "@/components/ui/button";
-import { Shield, Home, Wrench, GraduationCap, Briefcase, Users, MessageSquare, Mail, Settings, BookOpen, Info, FileText, LifeBuoy, Rss, PenTool } from "lucide-react";
+import {
+  Shield,
+  Home,
+  Wrench,
+  GraduationCap,
+  Briefcase,
+  Users,
+  MessageSquare,
+  Mail,
+  Settings,
+  BookOpen,
+  Info,
+  FileText,
+  LifeBuoy,
+  Rss,
+  PenTool,
+} from "lucide-react";
 import { useAuth } from "@/context/AuthContext";
+import { useLanguage } from "@/context/LanguageContext";
 
 const navItems = [
-  { label: "Home", path: "/", icon: Home },
-  { label: "Services", path: "/services", icon: Wrench },
-  { label: "Academy", path: "/academy", icon: GraduationCap },
-  { label: "Jobs", path: "/jobs", icon: Briefcase },
-  { label: "Freelancers", path: "/freelancers", icon: Users },
-  { label: "Blog", path: "/blog", icon: PenTool },
-  { label: "Chat", path: "/chat", icon: MessageSquare },
-  { label: "Newsletter", path: "/newsletter", icon: Mail },
-  { label: "Tools", path: "/tools", icon: Settings },
-  { label: "3D Model", path: "/3d", icon: BookOpen },
-  { label: "About", path: "/about", icon: Info },
-  { label: "FAQ", path: "/faq", icon: FileText },
-  { label: "Support", path: "/support", icon: LifeBuoy },
-  { label: "Infrastructure", path: "/infrastructure" },
-  { label: "Privacy", path: "/privacy-policy" },
-  { label: "Terms", path: "/terms-of-service" },
-  { label: "RSS", path: "/rss", icon: Rss },
+  { labelKey: "nav.home", path: "/", icon: Home },
+  { labelKey: "nav.services", path: "/services", icon: Wrench },
+  { labelKey: "nav.academy", path: "/academy", icon: GraduationCap },
+  { labelKey: "nav.jobs", path: "/jobs", icon: Briefcase },
+  { labelKey: "nav.freelancers", path: "/freelancers", icon: Users },
+  { labelKey: "nav.blog", path: "/blog", icon: PenTool },
+  { labelKey: "nav.liveChat", path: "/chat", icon: MessageSquare },
+  { labelKey: "nav.newsletter", path: "/newsletter", icon: Mail },
+  { labelKey: "nav.tools", path: "/tools", icon: Settings },
+  { labelKey: "nav.model3d", path: "/3d", icon: BookOpen },
+  { labelKey: "nav.about", path: "/about", icon: Info },
+  { labelKey: "nav.faq", path: "/faq", icon: FileText },
+  { labelKey: "nav.support", path: "/support", icon: LifeBuoy },
+  { labelKey: "nav.infrastructure", path: "/infrastructure" },
+  { labelKey: "nav.privacy", path: "/privacy-policy" },
+  { labelKey: "nav.terms", path: "/terms-of-service" },
+  { labelKey: "nav.rss", path: "/rss", icon: Rss },
 ];
 
 export default function DesktopNavigation() {
   const { isAuthenticated } = useAuth();
+  const { t } = useLanguage();
   const location = useLocation();
   const isAdmin = false; // Simplified for now - can be enhanced later with profile data
 
@@ -41,7 +59,7 @@ export default function DesktopNavigation() {
           >
             <Link to={item.path}>
               {item.icon && <item.icon className="inline-block mr-1 h-4 w-4" />}
-              {item.label}
+              {t(item.labelKey)}
             </Link>
           </Button>
         );

--- a/src/components/navbar/MobileNavigation.tsx
+++ b/src/components/navbar/MobileNavigation.tsx
@@ -2,30 +2,48 @@ import React from "react";
 import { Link, useLocation } from "react-router-dom";
 import { Button } from "@/components/ui/button";
 import { useAuth } from "@/context/AuthContext";
-import { Shield, Home, Wrench, GraduationCap, Briefcase, Users, MessageSquare, Mail, Settings, BookOpen, Info, FileText, LifeBuoy, Rss, PenTool } from "lucide-react";
+import {
+  Shield,
+  Home,
+  Wrench,
+  GraduationCap,
+  Briefcase,
+  Users,
+  MessageSquare,
+  Mail,
+  Settings,
+  BookOpen,
+  Info,
+  FileText,
+  LifeBuoy,
+  Rss,
+  PenTool,
+} from "lucide-react";
+import { useLanguage } from "@/context/LanguageContext";
 
 const navItems = [
-  { label: "Home", path: "/", icon: Home },
-  { label: "Services", path: "/services", icon: Wrench },
-  { label: "Academy", path: "/academy", icon: GraduationCap },
-  { label: "Jobs", path: "/jobs", icon: Briefcase },
-  { label: "Freelancers", path: "/freelancers", icon: Users },
-  { label: "Blog", path: "/blog", icon: PenTool },
-  { label: "Chat", path: "/chat", icon: MessageSquare },
-  { label: "Newsletter", path: "/newsletter", icon: Mail },
-  { label: "Tools", path: "/tools", icon: Settings },
-  { label: "3D Model", path: "/3d", icon: BookOpen },
-  { label: "About", path: "/about", icon: Info },
-  { label: "FAQ", path: "/faq", icon: FileText },
-  { label: "Support", path: "/support", icon: LifeBuoy },
-  { label: "Infrastructure", path: "/infrastructure" },
-  { label: "Privacy", path: "/privacy-policy" },
-  { label: "Terms", path: "/terms-of-service" },
-  { label: "RSS", path: "/rss", icon: Rss },
+  { labelKey: "nav.home", path: "/", icon: Home },
+  { labelKey: "nav.services", path: "/services", icon: Wrench },
+  { labelKey: "nav.academy", path: "/academy", icon: GraduationCap },
+  { labelKey: "nav.jobs", path: "/jobs", icon: Briefcase },
+  { labelKey: "nav.freelancers", path: "/freelancers", icon: Users },
+  { labelKey: "nav.blog", path: "/blog", icon: PenTool },
+  { labelKey: "nav.liveChat", path: "/chat", icon: MessageSquare },
+  { labelKey: "nav.newsletter", path: "/newsletter", icon: Mail },
+  { labelKey: "nav.tools", path: "/tools", icon: Settings },
+  { labelKey: "nav.model3d", path: "/3d", icon: BookOpen },
+  { labelKey: "nav.about", path: "/about", icon: Info },
+  { labelKey: "nav.faq", path: "/faq", icon: FileText },
+  { labelKey: "nav.support", path: "/support", icon: LifeBuoy },
+  { labelKey: "nav.infrastructure", path: "/infrastructure" },
+  { labelKey: "nav.privacy", path: "/privacy-policy" },
+  { labelKey: "nav.terms", path: "/terms-of-service" },
+  { labelKey: "nav.rss", path: "/rss", icon: Rss },
 ];
 
 export default function MobileNavigation({ onNavigate }: { onNavigate?: () => void }) {
   const { isAuthenticated, user } = useAuth();
+  const { t } = useLanguage();
   const location = useLocation();
   const isAdmin = false; // Simplified for now - can be enhanced later with profile data
 
@@ -42,7 +60,7 @@ export default function MobileNavigation({ onNavigate }: { onNavigate?: () => vo
           >
             <Link to={item.path}>
               {item.icon && <item.icon className="inline-block mr-1 h-4 w-4" />}
-              {item.label}
+              {t(item.labelKey)}
             </Link>
           </Button>
         );

--- a/src/context/translations/ar.ts
+++ b/src/context/translations/ar.ts
@@ -22,6 +22,12 @@ export const arTranslations = {
   "nav.joinTelegram": "انضم إلى تلغرام",
   "nav.liveChat": "دردشة مباشرة",
   "nav.threatMap": "خريطة التهديدات",
+  "nav.blog": "مدونة",
+  "nav.tools": "أدوات",
+  "nav.model3d": "نموذج ثلاثي الأبعاد",
+  "nav.privacy": "الخصوصية",
+  "nav.terms": "الشروط",
+  "nav.rss": "RSS",
 
   // Hero Section
   "hero.title": "شريكك في بناء وإصلاح وتأمين المستقبل الرقمي",

--- a/src/context/translations/en.ts
+++ b/src/context/translations/en.ts
@@ -22,6 +22,12 @@ export const enTranslations = {
   "nav.joinTelegram": "Join Telegram",
   "nav.liveChat": "Live Chat",
   "nav.threatMap": "Threat Map",
+  "nav.blog": "Blog",
+  "nav.tools": "Tools",
+  "nav.model3d": "3D Model",
+  "nav.privacy": "Privacy",
+  "nav.terms": "Terms",
+  "nav.rss": "RSS",
 
   // Hero Section
   "hero.title": "Your Partner in Building, Repairing & Securing Digital Futures",

--- a/src/context/translations/fr.ts
+++ b/src/context/translations/fr.ts
@@ -22,6 +22,12 @@ export const frTranslations = {
   "nav.joinTelegram": "Rejoindre Telegram",
   "nav.liveChat": "Chat en Direct",
   "nav.threatMap": "Carte des Menaces",
+  "nav.blog": "Blog",
+  "nav.tools": "Outils",
+  "nav.model3d": "Modèle 3D",
+  "nav.privacy": "Confidentialité",
+  "nav.terms": "Conditions",
+  "nav.rss": "RSS",
 
   // Hero Section
   "hero.title": "Votre Partenaire pour Construire, Réparer et Sécuriser l'Avenir Numérique",


### PR DESCRIPTION
## Summary
- add English, French, and Arabic strings for Blog, Tools, 3D Model, Privacy, Terms, and RSS
- use LanguageContext translations for desktop and mobile navigation

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: Unexpected any. Specify a different type)*

------
https://chatgpt.com/codex/tasks/task_e_688d798d7f20832e9abfe425ac9705d1