### PR TITLE
feat: add gravatar caching

### DIFF
--- a/index.html
+++ b/index.html
@@ -27,8 +27,9 @@
     <meta name="twitter:image" content="https://zwanski.org/og-image.png" />
     <link rel="icon" href="/favicon-professional.svg" type="image/svg+xml">
     <link rel="icon" href="/favicon.png" type="image/png">
-    
+
     <link rel="apple-touch-icon" href="/favicon-professional.svg">
+    <link rel="manifest" href="/manifest.webmanifest">
     
     <!-- Security Headers -->
     <meta http-equiv="Strict-Transport-Security" content="max-age=31536000; includeSubDomains; preload">

--- a/public/manifest.webmanifest
+++ b/public/manifest.webmanifest
@@ -1,0 +1,20 @@
+{
+  "name": "Zwanski Tech",
+  "short_name": "Zwanski",
+  "start_url": "/",
+  "display": "standalone",
+  "background_color": "#ffffff",
+  "description": "Zwanski Tech PWA",
+  "icons": [
+    {
+      "src": "/favicon.png",
+      "sizes": "512x512",
+      "type": "image/png"
+    },
+    {
+      "src": "/favicon-professional.svg",
+      "sizes": "512x512",
+      "type": "image/svg+xml"
+    }
+  ]
+}

--- a/public/service-worker.js
+++ b/public/service-worker.js
@@ -1,0 +1,36 @@
+const CACHE_NAME = 'gravatar-cache-v1';
+const GRAVATAR_URL = 'https://www.gravatar.com';
+
+self.addEventListener('install', (event) => {
+  event.waitUntil(
+    caches.open(CACHE_NAME).then((cache) =>
+      cache.add('https://www.gravatar.com/avatar/?d=mp&f=y')
+    )
+  );
+  self.skipWaiting();
+});
+
+self.addEventListener('activate', (event) => {
+  event.waitUntil(self.clients.claim());
+});
+
+self.addEventListener('fetch', (event) => {
+  const { request } = event;
+  if (request.url.startsWith(GRAVATAR_URL)) {
+    event.respondWith(
+      caches.open(CACHE_NAME).then(async (cache) => {
+        const cached = await cache.match(request);
+        if (cached) {
+          return cached;
+        }
+        try {
+          const networkResponse = await fetch(request);
+          cache.put(request, networkResponse.clone());
+          return networkResponse;
+        } catch (error) {
+          return cached;
+        }
+      })
+    );
+  }
+});

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -5,3 +5,11 @@ import './styles/performance.css'
 import './styles/homepage-stability.css'
 
 createRoot(document.getElementById("root")!).render(<App />);
+
+if ('serviceWorker' in navigator) {
+  window.addEventListener('load', () => {
+    navigator.serviceWorker
+      .register('/service-worker.js')
+      .catch((err) => console.error('SW registration failed', err));
+  });
+}


### PR DESCRIPTION
## Summary
- add basic PWA manifest and service worker
- cache gravatar avatar requests for offline access

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run lint` (fails: Cannot find package '@eslint/js')
- `npm run build` (fails: vite: not found)


------
https://chatgpt.com/codex/tasks/task_e_688d79a43cf0832eb031079c07024129