### PR TITLE
feat: add timeout to check IMEI function

### DIFF
--- a/supabase/functions/check-imei/index.ts
+++ b/supabase/functions/check-imei/index.ts
@@ -46,11 +46,31 @@ serve(async (req) => {
     formData.append('imei', imei);
     formData.append('key', apiKey);
 
-    // Make request to IMEI API
-    const response = await fetch('https://api.ifreeicloud.co.uk', {
-      method: 'POST',
-      body: formData,
-    });
+    // Make request to IMEI API with timeout
+    const controller = new AbortController();
+    const timeout = setTimeout(() => controller.abort(), 10000);
+    let response;
+    try {
+      response = await fetch('https://api.ifreeicloud.co.uk', {
+        method: 'POST',
+        body: formData,
+        signal: controller.signal,
+      });
+    } catch (err) {
+      if (err.name === 'AbortError') {
+        console.error('IMEI API request timed out');
+        return new Response(
+          JSON.stringify({ error: 'IMEI check service timed out' }),
+          {
+            status: 504,
+            headers: { ...corsHeaders, 'Content-Type': 'application/json' }
+          }
+        );
+      }
+      throw err;
+    } finally {
+      clearTimeout(timeout);
+    }
 
     if (!response.ok) {
       console.error('IMEI API error:', response.status, response.statusText);


### PR DESCRIPTION
## Summary
- enforce 10s timeout on external IMEI API requests using `AbortController`
- return a 504 Gateway Timeout error when the IMEI API request exceeds the allotted time

## Testing
- `npm test` *(fails: Missing script "test")*
- `npx eslint supabase/functions/check-imei/index.ts`


------
https://chatgpt.com/codex/tasks/task_e_688d79aef0c0832eb93552f10d72e7ad