### PR TITLE
feat: track profile fetch analytics

### DIFF
--- a/src/components/ChatWidget.tsx
+++ b/src/components/ChatWidget.tsx
@@ -8,6 +8,7 @@ import LoginForm from "@/components/LoginForm";
 import { useToast } from "@/hooks/use-toast";
 import { cn } from "@/lib/utils";
 import { supabase } from "@/integrations/supabase/client";
+import { trackEvent } from "@/utils/analytics";
 interface ChatMessageType {
   id: number;
   message: string;
@@ -52,6 +53,7 @@ const ChatWidget = () => {
         return;
       }
       setUserProfile(data);
+      trackEvent('profile_fetch', { user_id: user.id, email: user.email });
     } catch (error) {
       console.error("Error fetching user profile:", error);
     }

--- a/src/components/Navbar.tsx
+++ b/src/components/Navbar.tsx
@@ -10,6 +10,7 @@ import { GlobalSearchBar } from "./search/GlobalSearchBar";
 import { UserMenu } from "./navbar/UserMenu";
 import { NotificationButton } from "./navbar/NotificationButton";
 import { supabase } from "@/integrations/supabase/client";
+import { trackEvent } from "@/utils/analytics";
 
 const Navbar = () => {
   const navigate = useNavigate();
@@ -44,6 +45,7 @@ const Navbar = () => {
         return;
       }
       setUserProfile(data);
+      trackEvent('profile_fetch', { user_id: user.id, email: user.email });
     } catch (error) {
       if (process.env.NODE_ENV === 'development') {
         console.error("Error fetching user profile:", error);

--- a/src/hooks/useLegacyAuth.ts
+++ b/src/hooks/useLegacyAuth.ts
@@ -2,6 +2,7 @@
 import { useState, useEffect } from 'react';
 import { supabase } from '@/integrations/supabase/client';
 import { User } from '@supabase/supabase-js';
+import { trackEvent } from '@/utils/analytics';
 
 interface ChatUser {
   id: string;
@@ -43,9 +44,11 @@ export const useAuth = () => {
             username: profile?.full_name || session.user.email?.split('@')[0] || 'User',
             avatar: ''
           };
-          
+
           setUser(enhancedUser);
-          
+
+          trackEvent('profile_fetch', { user_id: session.user.id, email: session.user.email });
+
           // Set chat user for compatibility
           setChatUser({
             id: session.user.id,
@@ -79,9 +82,11 @@ export const useAuth = () => {
             username: profile?.full_name || session.user.email?.split('@')[0] || 'User',
             avatar: ''
           };
-          
+
           setUser(enhancedUser);
-          
+
+          trackEvent('profile_fetch', { user_id: session.user.id, email: session.user.email });
+
           // Set chat user for compatibility
           setChatUser({
             id: session.user.id,

--- a/src/pages/Chat.tsx
+++ b/src/pages/Chat.tsx
@@ -13,6 +13,7 @@ import { useWebSocket } from "@/hooks/useWebSocket";
 import { useToast } from "@/hooks/use-toast";
 import { supabase } from "@/integrations/supabase/client";
 import { Profile } from "@/types/profile";
+import { trackEvent } from "@/utils/analytics";
 
 const Chat = () => {
   const { user, isAuthenticated, signOut } = useAuth();
@@ -46,6 +47,7 @@ const Chat = () => {
       }
 
       setUserProfile(data);
+      trackEvent('profile_fetch', { user_id: user.id, email: user.email });
     } catch (error) {
       console.error("Error fetching user profile:", error);
     }

--- a/src/utils/analytics.ts
+++ b/src/utils/analytics.ts
@@ -1,0 +1,23 @@
+export function anonymizeEmail(email: string): string {
+  if (!email) return '';
+  const [localPart, domain] = email.split('@');
+  if (!localPart || !domain) return '';
+  return `${localPart[0]}***@${domain}`;
+}
+
+declare global {
+  interface Window {
+    gtag?: (...args: unknown[]) => void;
+  }
+}
+
+export function trackEvent(eventName: string, params: Record<string, unknown> = {}): void {
+  const payload = { ...params } as Record<string, unknown> & { email?: string };
+  if (payload.email) {
+    payload.email = anonymizeEmail(payload.email);
+  }
+  if (typeof window !== 'undefined' && typeof window.gtag === 'function') {
+    window.gtag('event', eventName, payload);
+  }
+}
+


### PR DESCRIPTION
## Summary
- add analytics helper that anonymizes emails before sending events
- log `profile_fetch` analytics event from profile retrieval across navigation, chat, and auth flows

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: 88 problems (63 errors, 25 warnings))*

------
https://chatgpt.com/codex/tasks/task_e_688d79b04b5c832e982d3a51b81cddcb