### PR TITLE
feat: add CSRF protection for profile updates

### DIFF
--- a/AUTHENTICATION_SETUP.md
+++ b/AUTHENTICATION_SETUP.md
@@ -89,6 +89,16 @@ The following secrets should already be configured in your Supabase project:
 2. Test with invalid credentials (should show appropriate errors)
 3. Verify rate limiting works (multiple failed attempts)
 
+### CSRF Token Refresh and Validation
+
+The `/profile/update` endpoint uses a double-submit CSRF token. Clients must:
+
+1. Read the `csrf-token` cookie and send its value in the `X-CSRF-Token` header for each POST request.
+2. After a successful response, update the stored token with the new value set in the `csrf-token` cookie.
+3. If the token is missing or mismatched, the request will be rejected with a `403` status.
+
+Refreshing the token is automatic; simply capture the latest `csrf-token` cookie after each profile update.
+
 ## 🔧 Troubleshooting
 
 ### Common Issues

--- a/src/hooks/useFreelancerProfiles.ts
+++ b/src/hooks/useFreelancerProfiles.ts
@@ -1,6 +1,7 @@
 
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
 import { supabase } from '@/integrations/supabase/client';
+import { updateProfile } from '@/services/profile';
 
 export interface FreelancerProfile {
   id: string;
@@ -117,18 +118,12 @@ export const useUpdateFreelancerProfile = () => {
       availability?: string;
       experience_years?: number;
     }) => {
-      const { data, error } = await supabase
-        .from('freelancer_profiles')
-        .update(profileData)
-        .eq('id', id)
-        .select()
-        .single();
-      
-      if (error) {
+      try {
+        return await updateProfile({ id, ...profileData });
+      } catch (error) {
         console.error('Error updating freelancer profile:', error);
         throw error;
       }
-      return data;
     },
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ['freelancer-profiles'] });

--- a/src/services/profile.ts
+++ b/src/services/profile.ts
@@ -1,0 +1,25 @@
+import { getCsrfToken } from '@/utils/csrf';
+
+export interface ProfileUpdate {
+  id: string;
+  [key: string]: any;
+}
+
+export async function updateProfile(data: ProfileUpdate) {
+  const csrfToken = getCsrfToken();
+  const res = await fetch('/profile/update', {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      'X-CSRF-Token': csrfToken ?? '',
+    },
+    credentials: 'include',
+    body: JSON.stringify(data),
+  });
+
+  if (!res.ok) {
+    throw new Error('Failed to update profile');
+  }
+
+  return res.json();
+}

--- a/src/utils/csrf.ts
+++ b/src/utils/csrf.ts
@@ -1,0 +1,6 @@
+export function getCsrfToken(): string | undefined {
+  return document.cookie
+    .split('; ')
+    .find((row) => row.startsWith('csrf-token='))
+    ?.split('=')[1];
+}

--- a/supabase/functions/profile-update/index.ts
+++ b/supabase/functions/profile-update/index.ts
@@ -1,0 +1,70 @@
+import { serve } from "https://deno.land/std@0.168.0/http/server.ts";
+import { createClient } from "https://esm.sh/@supabase/supabase-js@2";
+
+const corsHeaders = {
+  "Access-Control-Allow-Origin": "*",
+  "Access-Control-Allow-Headers": "authorization, x-client-info, apikey, content-type, x-csrf-token",
+  "Access-Control-Allow-Credentials": "true",
+};
+
+function getCookie(req: Request, name: string): string | undefined {
+  const cookie = req.headers.get("Cookie");
+  return cookie
+    ?.split("; ")
+    .find((c) => c.startsWith(`${name}=`))
+    ?.split("=")[1];
+}
+
+serve(async (req) => {
+  if (req.method === "OPTIONS") {
+    return new Response(null, { headers: corsHeaders });
+  }
+
+  const csrfCookie = getCookie(req, "csrf-token");
+  const csrfHeader = req.headers.get("x-csrf-token");
+
+  if (!csrfCookie || !csrfHeader || csrfCookie !== csrfHeader) {
+    return new Response(
+      JSON.stringify({ error: "Invalid CSRF token" }),
+      { status: 403, headers: { ...corsHeaders, "Content-Type": "application/json" } },
+    );
+  }
+
+  try {
+    const { id, ...profileData } = await req.json();
+
+    const supabaseUrl = Deno.env.get("SUPABASE_URL")!;
+    const supabaseKey = Deno.env.get("SUPABASE_SERVICE_ROLE_KEY")!;
+    const supabase = createClient(supabaseUrl, supabaseKey);
+
+    const { data, error } = await supabase
+      .from("freelancer_profiles")
+      .update(profileData)
+      .eq("id", id)
+      .select()
+      .single();
+
+    if (error) {
+      return new Response(
+        JSON.stringify({ error: error.message }),
+        { status: 400, headers: { ...corsHeaders, "Content-Type": "application/json" } },
+      );
+    }
+
+    return new Response(
+      JSON.stringify({ data }),
+      {
+        headers: {
+          ...corsHeaders,
+          "Content-Type": "application/json",
+          "Set-Cookie": `csrf-token=${crypto.randomUUID()}; Path=/; HttpOnly; SameSite=Strict`,
+        },
+      },
+    );
+  } catch (err) {
+    return new Response(
+      JSON.stringify({ error: "Internal server error" }),
+      { status: 500, headers: { ...corsHeaders, "Content-Type": "application/json" } },
+    );
+  }
+});


### PR DESCRIPTION
## Summary
- add CSRF helper and profile update service
- require CSRF token in freelancer profile updates
- secure `/profile/update` edge function and document token refresh

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: 89 problems)*

------
https://chatgpt.com/codex/tasks/task_e_688d79b0e510832e97c8fd1360e8d881