### PR TITLE
fix: remove trailing comma in scripts

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "dev:admin": "vite --config admin/vite.config.ts --root admin",
     "build:admin": "vite build --config admin/vite.config.ts --root admin",
     "lint": "eslint .",
-    "preview": "vite preview",
+    "preview": "vite preview"
   },
   "dependencies": {
     "@hookform/resolvers": "^3.9.0",


### PR DESCRIPTION
## Summary
- remove trailing comma from `preview` entry in `scripts`

## Testing
- `npm install --no-fund --no-audit --legacy-peer-deps`
- `npm test` (fails: Missing script "test")
- `npm run lint` (fails: 65 errors, 26 warnings)


------
https://chatgpt.com/codex/tasks/task_e_688ed5d89f4c832e9a7ef1e8143a33f9