### PR TITLE
fix: use moduleNameMapper in Jest config

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -1,7 +1,7 @@
 export default {
   preset: 'ts-jest/presets/default-esm',
   testEnvironment: 'jsdom',
-  moduleNameMapping: {
+  moduleNameMapper: {
     '^@/(.*)$': '<rootDir>/src/$1',
     '^(\\.{1,2}/.*)\\.js$': '$1',
   },


### PR DESCRIPTION
## Summary
- replace deprecated moduleNameMapping with moduleNameMapper in Jest config to maintain path alias resolution

## Testing
- `npm test` *(fails: Invalid package.json – JSONParseError)*
- `npm run lint` *(fails: Invalid package.json – JSONParseError)*

------
https://chatgpt.com/codex/tasks/task_e_688ed5dafce8832ebb7ae9b70aa0f39f