### PR TITLE
refactor: use env vars for Supabase config

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,5 +1,7 @@
 SUPABASE_URL=
 SUPABASE_ANON_KEY=
+VITE_SUPABASE_URL=
+VITE_SUPABASE_ANON_KEY=
 
 # Cloudflare Turnstile Configuration
 VITE_TURNSTILE_SITE_KEY=your_cloudflare_turnstile_site_key_here

--- a/admin/src/supabase/client.ts
+++ b/admin/src/supabase/client.ts
@@ -1,6 +1,11 @@
 import { createClient } from '@supabase/supabase-js';
 
-const SUPABASE_URL = import.meta.env.VITE_SUPABASE_URL as string;
-const SUPABASE_ANON_KEY = import.meta.env.VITE_SUPABASE_ANON_KEY as string;
+const SUPABASE_URL =
+  (import.meta as any).env?.VITE_SUPABASE_URL ?? process.env.SUPABASE_URL;
+const SUPABASE_ANON_KEY =
+  (import.meta as any).env?.VITE_SUPABASE_ANON_KEY ?? process.env.SUPABASE_ANON_KEY;
 
-export const supabase = createClient(SUPABASE_URL, SUPABASE_ANON_KEY);
+export const supabase = createClient(
+  SUPABASE_URL as string,
+  SUPABASE_ANON_KEY as string
+);

--- a/src/integrations/supabase/client.ts
+++ b/src/integrations/supabase/client.ts
@@ -2,10 +2,16 @@
 import { createClient } from '@supabase/supabase-js';
 import type { Database } from './types';
 
-const SUPABASE_URL = "https://ceihcnfngpmrtqunhaey.supabase.co";
-const SUPABASE_ANON_KEY = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6ImNlaWhjbmZuZ3BtcnRxdW5oYWV5Iiwicm9sZSI6ImFub24iLCJpYXQiOjE3NTAxMTIwNzMsImV4cCI6MjA2NTY4ODA3M30.I2Yit_peN5PiTq54Y-4hrDowH3wEWa7lZPT0UgKdXSc";
+const SUPABASE_URL =
+  (import.meta as any).env?.VITE_SUPABASE_URL ?? process.env.SUPABASE_URL;
+const SUPABASE_ANON_KEY =
+  (import.meta as any).env?.VITE_SUPABASE_ANON_KEY ?? process.env.SUPABASE_ANON_KEY;
 
 // Import the supabase client like this:
 // import { supabase } from "@/integrations/supabase/client";
 
-export const supabase = createClient<Database>(SUPABASE_URL, SUPABASE_ANON_KEY);
+export const supabase = createClient<Database>(
+  SUPABASE_URL as string,
+  SUPABASE_ANON_KEY as string
+);
+


### PR DESCRIPTION
## Summary
- read Supabase credentials from environment variables
- document Supabase env vars
- align admin Supabase client with env-based config

## Testing
- `npm test` *(fails: Invalid package.json)*
- `npm run lint` *(fails: Invalid package.json)*


------
https://chatgpt.com/codex/tasks/task_e_688ed5fed250832eb5c90192d73104fb