### PR TITLE
fix: remove duplicate subscription status type

### DIFF
--- a/src/integrations/supabase/types.ts
+++ b/src/integrations/supabase/types.ts
@@ -2039,7 +2039,6 @@ export type Database = {
           user_type: Database["public"]["Enums"]["user_type"]
           verified: boolean | null
           website: string | null
-          subscription_status: string | null
           subscription_start_date: string | null
           subscription_end_date: string | null
           years_experience: number | null
@@ -2082,7 +2081,6 @@ export type Database = {
           user_type: Database["public"]["Enums"]["user_type"]
           verified?: boolean | null
           website?: string | null
-          subscription_status?: string | null
           subscription_start_date?: string | null
           subscription_end_date?: string | null
           years_experience?: number | null
@@ -2125,7 +2123,6 @@ export type Database = {
           user_type?: Database["public"]["Enums"]["user_type"]
           verified?: boolean | null
           website?: string | null
-          subscription_status?: string | null
           subscription_start_date?: string | null
           subscription_end_date?: string | null
           years_experience?: number | null


### PR DESCRIPTION
## Summary
- remove duplicate subscription_status definitions in Supabase profile types

## Testing
- `npx supabase gen types typescript --project-id ceihcnfngpmrtqunhaey --schema public` *(fails: Access token not provided)*
- `npm test` *(fails: package.json parse error)*
- `npm run lint` *(fails: package.json parse error)*

------
https://chatgpt.com/codex/tasks/task_e_688eddeb8ef8832e8803596e8e908d2d